### PR TITLE
Setup for automated acceptance tests via Aptible Integration

### DIFF
--- a/aptible/provider_test.go
+++ b/aptible/provider_test.go
@@ -2,14 +2,14 @@ package aptible
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-// Replace this with relevant environment ID.
-const TestEnvironmentId = 4
+var testEnvironmentId int
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
@@ -19,6 +19,12 @@ func init() {
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"aptible": testAccProvider,
 	}
+
+	i := os.Getenv("APTIBLE_ENVIRONMENT_ID")
+
+	// Precheck confirms this will work
+	id, _ := strconv.Atoi(i)
+	testEnvironmentId = id
 }
 
 // Ensure we're pointing at a sandbox before we run and a token is provided
@@ -31,6 +37,14 @@ func testAccPreCheck(t *testing.T) {
 	}
 	if v := os.Getenv("APTIBLE_ACCESS_TOKEN"); v == "" {
 		t.Fatal("APTIBLE_ACCESS_TOKEN must be set for acceptance tests")
+	}
+
+	id := os.Getenv("APTIBLE_ENVIRONMENT_ID")
+	if id == "" {
+		t.Fatal("APTIBLE_ENVIRONMENT_ID must be set for acceptance tests")
+	}
+	if _, err := strconv.Atoi(id); err != nil {
+		t.Fatal("APTIBLE_ENVIRONMENT_ID is not a valid integer value")
 	}
 }
 

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -24,7 +24,7 @@ func TestAccResourceApp_basic(t *testing.T) {
 				Config: testAccAptibleAppBasic(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
 				),
@@ -45,7 +45,7 @@ func TestAccResourceApp_deploy(t *testing.T) {
 				Config: testAccAptibleAppDeploy(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
 					resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
@@ -68,7 +68,7 @@ func TestAccResourceApp_updateConfig(t *testing.T) {
 				Config: testAccAptibleAppDeploy(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
 					resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
@@ -117,7 +117,7 @@ resource "aptible_app" "test" {
     env_id = %d
     handle = "%v"
 }
-`, TestEnvironmentId, handle)
+`, testEnvironmentId, handle)
 }
 
 func testAccAptibleAppDeploy(handle string) string {
@@ -130,7 +130,7 @@ func testAccAptibleAppDeploy(handle string) string {
 			"WHATEVER" = "something"
 		}
 	}
-	`, TestEnvironmentId, handle)
+	`, testEnvironmentId, handle)
 }
 
 func testAccAptibleAppUpdateConfig(handle string) string {
@@ -143,5 +143,5 @@ func testAccAptibleAppUpdateConfig(handle string) string {
 			"WHATEVER" = "nothing"
 		}
 	}
-	`, TestEnvironmentId, handle)
+	`, testEnvironmentId, handle)
 }

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -26,7 +26,7 @@ func TestAccResourceDatabase_basic(t *testing.T) {
 				Config: testAccAptibleDatabaseBasic(dbHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_db.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_db.test", "db_type", "postgresql"),
 					resource.TestCheckResourceAttr("aptible_db.test", "container_size", "1024"),
 					resource.TestCheckResourceAttr("aptible_db.test", "disk_size", "10"),
@@ -50,7 +50,7 @@ func TestAccResourceDatabase_update(t *testing.T) {
 				Config: testAccAptibleDatabaseBasic(dbHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_db.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_db.test", "db_type", "postgresql"),
 					resource.TestCheckResourceAttr("aptible_db.test", "container_size", "1024"),
 					resource.TestCheckResourceAttr("aptible_db.test", "disk_size", "10"),
@@ -127,7 +127,7 @@ resource "aptible_db" "test" {
     env_id = %d
 	handle = "%v"
 }
-`, TestEnvironmentId, dbHandle)
+`, testEnvironmentId, dbHandle)
 }
 
 func testAccAptibleDatabaseUpdate(dbHandle string) string {
@@ -138,7 +138,7 @@ resource "aptible_db" "test" {
 	container_size = %d
 	disk_size = %d
 }
-`, TestEnvironmentId, dbHandle, 512, 20)
+`, testEnvironmentId, dbHandle, 512, 20)
 }
 
 func testAccAptibleDatabaseInvalidDBType(dbHandle string) string {
@@ -148,7 +148,7 @@ resource "aptible_db" "test" {
 	handle = "%v"
 	db_type = "%v"
 }
-`, TestEnvironmentId, dbHandle, "non-existent-db")
+`, testEnvironmentId, dbHandle, "non-existent-db")
 }
 
 func testAccAptibleDatabaseInvalidContainerSize(dbHandle string) string {
@@ -158,7 +158,7 @@ resource "aptible_db" "test" {
 	handle = "%v"
 	container_size = %d
 }
-`, TestEnvironmentId, dbHandle, 0)
+`, testEnvironmentId, dbHandle, 0)
 }
 
 func testAccAptibleDatabaseInvalidDiskSize(dbHandle string) string {
@@ -168,5 +168,5 @@ resource "aptible_db" "test" {
 	handle = "%v"
 	disk_size = %d
 }
-`, TestEnvironmentId, dbHandle, 0)
+`, testEnvironmentId, dbHandle, 0)
 }

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -26,11 +26,11 @@ func TestAccResourceEndpoint_app(t *testing.T) {
 				Config: testAccAptibleEndpointApp(appHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", appHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
 
-					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "resource_type", "app"),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "endpoint_type", "HTTPS"),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "true"),
@@ -55,11 +55,11 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 				Config: testAccAptibleEndpointDatabase(dbHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_db.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttrSet("aptible_db.test", "db_id"),
 					resource.TestCheckResourceAttrSet("aptible_db.test", "connection_url"),
 
-					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "resource_type", "database"),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "endpoint_type", "TCP"),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "false"),
@@ -84,11 +84,11 @@ func TestAccResourceEndpoint_updateIPWhitelist(t *testing.T) {
 				Config: testAccAptibleEndpointApp(appHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", appHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
 					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
 
-					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "resource_type", "app"),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "endpoint_type", "HTTPS"),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "true"),
@@ -192,7 +192,7 @@ resource "aptible_endpoint" "test" {
 	endpoint_type = "https"
 	internal = true
 	platform = "alb"
-}`, TestEnvironmentId, appHandle, TestEnvironmentId)
+}`, testEnvironmentId, appHandle, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output
 }
@@ -214,7 +214,7 @@ resource "aptible_endpoint" "test" {
 	endpoint_type = "tcp"
 	internal = false
 	platform = "elb"
-}`, TestEnvironmentId, dbHandle, TestEnvironmentId)
+}`, testEnvironmentId, dbHandle, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output
 }
@@ -239,7 +239,7 @@ resource "aptible_endpoint" "test" {
 	ip_filtering = [
 		"1.1.1.1/32",
 	]
-}`, TestEnvironmentId, appHandle, TestEnvironmentId)
+}`, testEnvironmentId, appHandle, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output
 }
@@ -250,7 +250,7 @@ resource "aptible_endpoint" "test" {
 	env_id = %d
 	resource_id = 1
 	resource_type = "should-error"
-	}`, TestEnvironmentId)
+	}`, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output
 }
@@ -262,7 +262,7 @@ resource "aptible_endpoint" "test" {
 	resource_id = 1
 	resource_type = "app"
 	endpoint_type = "should-error"
-	}`, TestEnvironmentId)
+	}`, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output
 }
@@ -274,7 +274,7 @@ resource "aptible_endpoint" "test" {
 	resource_id = 1
 	resource_type = "app"
 	platform = "should-error"
-	}`, TestEnvironmentId)
+	}`, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output
 }

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -27,7 +27,7 @@ func TestAccResourceReplica_basic(t *testing.T) {
 				Config: testAccAptibleReplicaBasic(dbHandle, replicaHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_db.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_db.test", "db_type", "postgresql"),
 					resource.TestCheckResourceAttr("aptible_db.test", "container_size", "1024"),
 					resource.TestCheckResourceAttr("aptible_db.test", "disk_size", "10"),
@@ -35,7 +35,7 @@ func TestAccResourceReplica_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aptible_db.test", "connection_url"),
 
 					resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
-					resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
 					resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
 					resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
@@ -59,7 +59,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 				Config: testAccAptibleReplicaBasic(dbHandle, replicaHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_db.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_db.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_db.test", "db_type", "postgresql"),
 					resource.TestCheckResourceAttr("aptible_db.test", "container_size", "1024"),
 					resource.TestCheckResourceAttr("aptible_db.test", "disk_size", "10"),
@@ -67,7 +67,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aptible_db.test", "connection_url"),
 
 					resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
-					resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(TestEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
 					resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
 					resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
@@ -159,7 +159,7 @@ resource "aptible_replica" "test" {
 	handle = "%v"
 	primary_db_id = aptible_db.test.db_id
 }
-`, TestEnvironmentId, dbHandle, TestEnvironmentId, replicaHandle)
+`, testEnvironmentId, dbHandle, testEnvironmentId, replicaHandle)
 	log.Println("HCL generated:", output)
 	return output
 }
@@ -178,7 +178,7 @@ func testAccAptibleReplicaUpdate(dbHandle string, repHandle string) string {
 		container_size = %d
 		disk_size = %d
 	}
-`, TestEnvironmentId, dbHandle, TestEnvironmentId, repHandle, 512, 20)
+`, testEnvironmentId, dbHandle, testEnvironmentId, repHandle, 512, 20)
 	log.Println("HCL generated:", output)
 	return output
 }
@@ -191,7 +191,7 @@ resource "aptible_replica" "test" {
 	primary_db_id = "1"
 	container_size = %d
 }
-`, TestEnvironmentId, replicaHandle, 0)
+`, testEnvironmentId, replicaHandle, 0)
 }
 
 func testAccAptibleReplicaInvalidDiskSize(replicaHandle string) string {
@@ -202,5 +202,5 @@ resource "aptible_replica" "test" {
 	primary_db_id = "1"
 	disk_size = %d
 }
-`, TestEnvironmentId, replicaHandle, 0)
+`, testEnvironmentId, replicaHandle, 0)
 }

--- a/terraform.md
+++ b/terraform.md
@@ -1,21 +1,26 @@
 # Terraform Provider for Aptible Deploy
+
 To use the provider:
+
 1. Run `go build -o terraform-provider-aptible`.
 2. Add a config file in the root directory named `main.tf`.
 3. Run `terraform init`.
 4. Run `terraform plan`.
 5. Run `terraform apply`. **Warning: This step will cause real resources to be created!**
+
 ## Resources
+
 This provider has 4 resources: apps, databases, endpoints, and replicas.
 
 ### Apps
-- Deployment   
-    - Currently, only direct docker image deployment is supported. 
-    - For more information on direct docker image deployment, refer to the [Aptible Deploy documentation](https://www.aptible.com/documentation/deploy/reference/apps/image/direct-docker-image-deploy.html).
+
+- Deployment
+  - Currently, only direct docker image deployment is supported.
+  - For more information on direct docker image deployment, refer to the [Aptible Deploy documentation](https://www.aptible.com/documentation/deploy/reference/apps/image/direct-docker-image-deploy.html).
 - Configuration
-    - Configuration is done via setting environment variables. 
-    - For more information on configuration variables in Aptible Deploy, refer to the [Aptible Deploy documentation](https://www.aptible.com/documentation/deploy/reference/apps/configuration.html#configuration).
-    - Connecting to a database can be done using the variable `DATABASE_URL` and setting it to the database's connection URL.
+  - Configuration is done via setting environment variables.
+  - For more information on configuration variables in Aptible Deploy, refer to the [Aptible Deploy documentation](https://www.aptible.com/documentation/deploy/reference/apps/configuration.html#configuration).
+  - Connecting to a database can be done using the variable `DATABASE_URL` and setting it to the database's connection URL.
 
 ### Databases
 
@@ -24,65 +29,83 @@ This provider has 4 resources: apps, databases, endpoints, and replicas.
 ### Replicas
 
 ---
+
 ## Data Sources
+
 This provider has 1 data source: environments.
 
 ### Environments
+
 - The environments data source gets the environment ID corresponding to a given handle.
 
 ---
+
 ## Configuration
+
 You can find an example configuration file in `examples/main.tf`.
+
 ### Apps
+
 Below are the attributes defined in the app config with the accepted values.
 
-* **env_id (environment ID)**: use `data.aptible_environment.<environment_name>.env_id`.    
-    For example, if your environment is called `test`, then the config should contain:
-    > `env_id = data.aptible_environment.test.env_id`
+- **env_id (environment ID)**: use `data.aptible_environment.<environment_name>.env_id`.  
+   For example, if your environment is called `test`, then the config should contain:
 
-* **handle (app handle)**: the handle for your app.    
-    For example, if your app is called `test`, then the config should contain:
-    > `handle = "test"`
+  > `env_id = data.aptible_environment.test.env_id`
 
-* **config**: the configuration for your app. This can include:
-    - `APTIBLE_DOCKER_IMAGE` which is the docker image you want to use to deploy.
-    - `DATABASE_URL` which is the connection URL for a database.
-    - [More examples](https://www.aptible.com/documentation/deploy/reference/apps/configuration.html#configuration)
+- **handle (app handle)**: the handle for your app.  
+   For example, if your app is called `test`, then the config should contain:
+
+  > `handle = "test"`
+
+- **config**: the configuration for your app. This can include:
+  - `APTIBLE_DOCKER_IMAGE` which is the docker image you want to use to deploy.
+  - `DATABASE_URL` which is the connection URL for a database.
+  - [More examples](https://www.aptible.com/documentation/deploy/reference/apps/configuration.html#configuration)
     For example, if you wanted to deploy using the `nginx` image, then the config should contain:
     > `config = {"APTIBLE_DOCKER_IMAGE" = "nginx"}`
 
 The `app_id` and `git_repo` attributes will be generated upon running `terraform apply`.
-    
-### Databases    
+
+### Databases
+
 Below are the attributes defined in the database config with the accepted values.
-* **env_id**: the ID for your environment.
-* **handle**: the handle for your database.    
-* **db_type**: the type of your database.    
-* **container_size**: the container size for your database.   
-* **disk_size**: the disk size for your database.      
+
+- **env_id**: the ID for your environment.
+- **handle**: the handle for your database.
+- **db_type**: the type of your database.
+- **container_size**: the container size for your database.
+- **disk_size**: the disk size for your database.
 
 The `db_id` and `connection_url` attributes will be generated upon running `terraform apply`.
 
 ### Endpoints
+
 Below are the attributes defined in the endpoint config with the accepted values.
 
 ### Replicas
+
 Below are the attributes defined in the replica config with the accepted values.
 
 ### Environments
+
 Below are the attributes defined in the environment config with the accepted values.
-* **handle**: the handle for your environment.    
-    For example, if your environment is called `test`, then the config should contain:
-   > `handle = "test"`
+
+- **handle**: the handle for your environment.  
+   For example, if your environment is called `test`, then the config should contain:
+  > `handle = "test"`
 
 ---
+
 ## Acceptance Tests
+
 This provider has acceptance tests to test basic functionality for each resource, as well as tests to ensure that invalid inputs return errors.
 
 To run the acceptance tests:
-1. Change the TestEnvironmentId (found in `aptible/provider_test.go`) to the environment id of your environment.
+
+1. Set the `APTIBLE_ENVIRONMENT_ID` to the test environment ID to run acceptance tests against. This will create real AWS resources.
 2. Make sure your `APTIBLE_AUTH_ROOT_URL`, `APTIBLE_API_ROOT_URL`,
-and `APTIBLE_ACCESS_TOKEN` environment variables are set.
+   and `APTIBLE_ACCESS_TOKEN` environment variables are set.
 3. Run `make testacc`.
 
 **Warning: The tests currently take ~50 minutes to run.**


### PR DESCRIPTION
Update the provider to allow for automated running of the accept test via aptible-integration cron

- Set test environment via an environment variable. This lets us create a new on the fly in the integration suite
