### PR TITLE
Add CD pipeline for automated releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,49 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+- env:
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+  goos:
+    - freebsd
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - '386'
+    - arm
+    - arm64
+  ignore:
+    - goos: darwin
+      goarch: '386'
+    - goos: freebsd
+      goarch: arm64
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--no-tty"
+      - "--yes"
+      - "-u"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+release:
+  prerelease: auto
+changelog:
+  sort: asc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,35 @@
 dist: xenial
-sudo: required
+os: linux
 services:
   - docker
 language: go
 
+go:
+  - 1.13.x
+
 env:
   global: GOFLAGS=-mod=vendor
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - go: tip
-  include:
-    - go: "1.13.x"
-      name: "Code Lint"
-      script: make lint
-    - go: "1.13.x"
-      name: "Code UnitTest"
-      script:
-        - make test
 
 install:
   - make tools
   - go mod vendor
 
-# branches:
-#   only:
-#     - master
+jobs:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+  include:
+    - name: "Code Lint"
+      script: make lint
+    - name: "Code UnitTest"
+      script: make test
+    - stage: deploy
+      script: skip
+      before_deploy:
+        - echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --import --no-tty --batch --yes
+      deploy:
+        - provider: script
+          edge: true
+          script: curl -sL https://git.io/goreleaser | bash
+          on:
+            tags: true


### PR DESCRIPTION
Part of https://aptible.atlassian.net/browse/DP-299

Follows Hashicorp advice in:
https://www.terraform.io/docs/registry/providers/publishing.html#creating-a-github-release

When we create a new SEMVER formatted git tag, then travis will kick in
and run Goreleaser to create our binaries, checksums, and signatures
and upload them to a new GitHub release.

I loaded a GPG key into Travis and 1Password Dev vault to be used to sign the releases.

---

Example release for review is v0.0.0-pre: https://github.com/aptible/terraform-provider-aptible/releases
I'll remove that release and tag once this PR is approved.