### PR TITLE
We don't need a default port for endpoints

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -74,7 +74,6 @@ func resourceEndpoint() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 65535),
-				Default:      80,
 			},
 			"ip_filtering": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
This passes acceptance tests, which makes sense