### PR TITLE
Bump go-deploy version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go v0.55.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/aptible/go-deploy v0.0.0-20200727011216-15e858a3bd65
+	github.com/aptible/go-deploy v0.0.0-20200730000149-3423b8ec4fb2
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/aws/aws-sdk-go v1.30.0 // indirect
 	github.com/fatih/color v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/aptible/go-deploy v0.0.0-20200727011216-15e858a3bd65 h1:Spy5CaIxaQkZTL2v3L+67P2asT6STIH3HmMxAnbtVfI=
 github.com/aptible/go-deploy v0.0.0-20200727011216-15e858a3bd65/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
+github.com/aptible/go-deploy v0.0.0-20200730000149-3423b8ec4fb2 h1:JeGy8DKUCenBj1Z13NtDDn7k0YWXweo4CdCjy6O+WIg=
+github.com/aptible/go-deploy v0.0.0-20200730000149-3423b8ec4fb2/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
Bumped version includes improved invalid token error handling (https://github.com/aptible/go-deploy/pull/27)