### PR TITLE
Fix DB endpoint acceptance test

### DIFF
--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -85,7 +85,7 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 					resource.TestCheckResourceAttr("aptible_database.test", "handle", dbHandle),
 					resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
-					resource.TestCheckResourceAttrSet("aptible_database.test", "connection_url"),
+					resource.TestCheckResourceAttrSet("aptible_database.test", "default_connection_url"),
 
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(testEnvironmentId)),
 					resource.TestCheckResourceAttr("aptible_endpoint.test", "resource_type", "database"),


### PR DESCRIPTION
I missed updating this acceptance test spec, which was causing a failure
on aptible-integration:

https://travis-ci.com/github/aptible/aptible-integration/jobs/382592058#L1132

Updated the test to use the correct field value