### PR TITLE
Add versioned docs for display on the Registry

### DIFF
--- a/docs/data-sources/environments.md
+++ b/docs/data-sources/environments.md
@@ -1,0 +1,40 @@
+# Environment Data Source
+
+[Environments](https://www.aptible.com/documentation/deploy/reference/environments.html)
+are where all resources are created and managed. Currently the Aptible Deploy Terraform
+provider does not manage Environments, but this data source allows you to look-up the
+IDs of existing Environments for use within Terraform.
+
+## Example Usage
+
+### Determining the Environment ID
+
+If you have an Environment with the handle "techco-test-environment" you can
+create the data source:
+
+```hcl
+data "aptible_environment" "techco-test-environment" {
+    handle = "techco-test-environment"
+}
+```
+
+Once defined, you can use this data source in your resource definitions.
+For example, when defining an App:
+
+```hcl
+data "aptible_app" "techo-app" {
+    env_id = data.aptible_environment.techco-test-environment.env_id
+    handle = "techo-app"
+}
+```
+
+## Argument Reference
+
+- `handle` - The handle for the Environment. This must be all lower case, and
+  only contain letters, numbers, `-`, `_`, or `.`
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `id` - The unique ID for an Environment suitable for use in `env_id` attributes

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,173 @@
+# Aptible Provider
+
+## Example Usage
+
+### Authentication and Authorization
+
+Authorization and Authentication is controlled using the same mechanism
+that the [cli](https://www.aptible.com/documentation/deploy/cli.html) uses.
+Therefore, you should log into the account you want to use Terraform with using
+the `aptible login` CLI command before running any Terraform commands.
+
+### Determining the Environment ID
+
+Each resource managed via Terraform requires an Environment ID specifying which
+[Environment](https://www.aptible.com/documentation/deploy/reference/environments.html)
+the resource should be created in. Currently the Aptible Deploy Terraform
+provider does not manage Environments, so you will need the Environment ID for
+a pre-existing Environment. The easiest way to determine the Environment ID is
+by using the Environment data source. For example, if you have an Environment
+with the handle "techco-test-environment" you can create the data source:
+
+```hcl
+data "aptible_environment" "techco-test-environment" {
+    handle = "techco-test-environment"
+}
+```
+
+Once defined, you can use this data source in your resource definitions.
+For example, when defining an App:
+
+```hcl
+data "aptible_app" "techo-app" {
+    env_id = data.aptible_environment.techco-test-environment.env_id
+    handle = "techo-app"
+}
+```
+
+### Apps
+
+[Apps](https://www.aptible.com/documentation/deploy/reference/apps.html) can be
+created using the `terraform_aptible_app` resource.
+
+```hcl
+data "aptible_app" "APP_HANDLE" {
+    handle = "APP_HANDLE"
+}
+```
+
+#### Configuring and Deploying Apps
+
+!> Currently the only supported deployment method via Terraform is of
+Docker images hosted in a Docker image registry.
+
+Apps configurations can be managed via the nested `config` element.
+
+```hcl
+resource "aptible_app" "APP_HANDLE" {
+    env_id = ENVIRONMENT_ID
+    handle = "APP_HANDLE"
+    config = {
+        "KEY" = "value"
+    }
+}
+```
+
+If you specify a Docker image as the `APTIBLE_DOCKER_IMAGE`
+configuration value, that Docker image will be deployed to the App.
+Authentication for Docker images located in
+private repositories can be provided using the
+`APTIBLE_PRIVATE_REGISTRY_USERNAME` and
+`APTIBLE_PRIVATE_REGISTRY_PASSWORD` configuration values.
+
+```hcl
+resource "aptible_app" "APP_HANDLE" {
+    env_id = ENVIRONMENT_ID
+    handle = "APP_HANDLE"
+    config = {
+        "KEY" = "value"
+        "APTIBLE_DOCKER_IMAGE" = "quay.io/aptible/deploy-demo-app"
+        "APTIBLE_PRIVATE_REGISTRY_USERNAME" = "registry_username"
+        "APTIBLE_PRIVATE_REGISTRY_PASSWORD" = "registry_password"
+    }
+}
+```
+
+#### Scaling Services
+
+Each App is comprised of one or more
+[Services](https://www.aptible.com/documentation/deploy/reference/apps/services.html).
+These Services must be defined in the
+[Procfile](https://www.aptible.com/documentation/deploy/reference/apps/services/defining-services.html#explicit-services-procfiles)
+for your App.
+
+Services can be scaled independently both in terms of the number of running
+[containers](https://www.aptible.com/documentation/deploy/reference/containers.html)
+and size of the running Containers. This is done using the nested `service`
+element for the App resource:
+
+-> The `process_type` in the `service` element maps directly to the
+Service name used in the Procfile. If you are not using a Procfile,
+you will have a single Service with the `process_type` of `cmd`
+
+```hcl
+resource "aptible_app" "APP_HANDLE" {
+    env_id = ENVIRONMENT_ID
+    handle = "APP_HANDLE"
+    service {
+        process_type = "SERVICE_NAME1"
+        container_count = 1
+        container_memory_limit = 1024
+    }
+    service {
+        process_type = "SERVICE_NAME2"
+        container_count = 2
+        container_memory_limit = 2048
+    }
+}
+```
+
+### Endpoints
+
+Endpoints for
+[Apps](https://www.aptible.com/documentation/deploy/reference/apps/endpoints.html)
+and
+[Databases](https://www.aptible.com/documentation/deploy/reference/databases/endpoints.html)
+can be managed using the `terraform_aptible_endpoint` resource.
+
+```hcl
+resource "aptible_endpoint" "EXAMPLE" {
+    env_id = ENVIONMENT_ID
+    service_name = "SERVICE_NAME"
+    resource_id = aptible_app.APP_HANDLE.app_id
+    default_domain = true
+    endpoint_type = "https"
+    internal = false
+    platform = "alb"
+    container_port = 5000
+}
+```
+
+### Databases
+
+[Databases](https://www.aptible.com/documentation/deploy/reference/databases.html)
+can be managed using the `terraform_aptible_database` resource.
+
+```hcl
+resource "aptible_database" "DATABASE_HANDLE" {
+    env_id = ENVIRONMENT_ID
+    handle = "DATABASE_HANDLE"
+    database_type = "redis"
+    container_size = 512
+    disk_size = 10
+}
+```
+
+#### Replication
+
+Database [Replicas and
+Clusters](https://www.aptible.com/documentation/deploy/reference/databases/replication-clustering.html)
+can be created using the `terraform_aptible_replica` resource.
+
+```hcl
+resource "aptible_replica" "REPLICA_HANDLE" {
+    env_id = ENVIRONMENT_ID
+    primary_database_id = aptible_database.DATABASE_HANDLE.database_id
+    handle = "REPLICA_HANDLE"
+    disk_size = 30
+}
+```
+
+## Argument Reference
+
+There are currently no arguments to provide directly to the provider

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -1,0 +1,78 @@
+# Aptible App Resource
+
+This resource is used to create and manage
+[Apps](https://www.aptible.com/documentation/deploy/reference/apps.html)
+running on Aptible Deploy.
+
+## Example Usage
+
+Basic application deployment with configuration
+
+```hcl
+resource "aptible_app" "example_app" {
+    env_id = 123
+    handle = "example_app"
+    config = {
+        "KEY" = "value"
+        "APTIBLE_DOCKER_IMAGE" = "quay.io/aptible/deploy-demo-app"
+        "APTIBLE_PRIVATE_REGISTRY_USERNAME" = "registry_username"
+        "APTIBLE_PRIVATE_REGISTRY_PASSWORD" = "registry_password"
+    }
+}
+```
+
+Application with defined services to control scaling through Terraform
+
+```hcl
+resource "aptible_app" "APP_HANDLE" {
+    env_id = ENVIRONMENT_ID
+    handle = "APP_HANDLE"
+    service {
+        process_type = "SERVICE_NAME1"
+        container_count = 1
+        container_memory_limit = 1024
+    }
+    service {
+        process_type = "SERVICE_NAME2"
+        container_count = 2
+        container_memory_limit = 2048
+    }
+}
+```
+
+## Argument Reference
+
+- `env_id` - The ID of the environment you would like to deploy your
+  App in. See main provider documentation for more on how to determine what
+  you should use for `env_id`.
+- `handle` - The handle for the App. This must be all lower case, and
+  only contain letters, numbers, `-`, `_`, or `.`
+- `config` - (Optional) The configuration for the App. This should be a
+  map of `KEY = VALUE`.
+- `service` - (Optional) A block to manage scaling for services. See the main
+  provider docs for additional details.
+
+The `service` block supports:
+
+- `process_type` - The `process_type` maps directly to the Service name used in
+  the Procfile. If you are not using a Procfile, you will have a single Service
+  with the `process_type` of `cmd`
+- `container_count` - (Optional) The number of unique containers running the
+  service for horizontal scaling
+- `container_memory_limit` - (Optional) Increase the memory limit of each
+  container in the service for vertical scaling
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `app_id` - The unique ID of the application
+- `git_repo` - The git remote associated with the application
+
+## Import
+
+Existing Apps can be imported using the App ID. For example:
+
+```bash
+terraform import aptible_app.example-app <ID>
+```

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -1,0 +1,56 @@
+# Aptible Database Resource
+
+This resource is used to create and manage
+[Databases](https://www.aptible.com/documentation/deploy/reference/databases.html)
+running on Aptible Deploy.
+
+!> Changing the handle of a database will destroy the existing database and
+create a new one, resulting in a database without data. The old database can
+still be recovered by [restoring a
+backup](https://www.aptible.com/documentation/deploy/reference/databases/backups.html#restoring-from-a-backup)
+as long as your retention policy supports final backups.
+
+## Example Usage
+
+```hcl
+resource "aptible_database" "example_database" {
+    env_id = 123
+    handle = "example_database"
+    database_type = "redis"
+    version = ""
+    container_size = 512
+    disk_size = 10
+}
+```
+
+## Argument Reference
+
+- `env_id` - The ID of the environment you would like to deploy your
+  App in. See main provider documentation for more on how to determine what
+  you should use for `env_id`.
+- `handle` - The handle for the Database. This must be all lower case, and
+  only contain letters, numbers, `-`, `_`, or `.`
+- `database_type` - The type of Database.
+- `version` - (Optional) The version of the Database. If none is specified,
+  this defaults to the latest recommended version.
+- `container_size` - The size of container used for the Database, in MB
+  of RAM.
+- `disk_size` - The disk size of the Database, in GB.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `database_id` - The unique ID for the database
+- `database_image_id` - The image used for running the database. Normally only used for support or debugging purposes
+- `default_connection_url` - The default [database credentials](https://www.aptible.com/documentation/deploy/reference/databases/credentials.html)
+  in connection URL format
+- `connection_urls` - A list of all available database credentials in connection URL format
+
+## Import
+
+Existing Databases can be imported using the Database ID. For example:
+
+```bash
+terraform import aptible_database.example-database <ID>
+```

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -1,0 +1,64 @@
+# Aptible App Resource
+
+This resource is used to create and manage endpoints for
+[Apps](https://www.aptible.com/documentation/deploy/reference/apps/endpoints.html)
+and
+[Databases](https://www.aptible.com/documentation/deploy/reference/databases/endpoints.html)
+running on Aptible.
+
+## Example Usage
+
+```hcl
+resource "aptible_endpoint" "example_endpoint" {
+    env_id = 123
+    service_name = "cmd"
+    resource_id = aptible_app.example_app.app_id
+    default_domain = true
+    endpoint_type = "https"
+    internal = false
+    platform = "alb"
+    container_port = 5000
+    managed = true
+}
+```
+
+## Argument Reference
+
+- `env_id` - The ID of the environment you would like to deploy your
+  App in. See main provider documentation for more on how to determine what
+  you should use for `env_id`.
+- `container_port` - (Optional, Apps only) The port on the container which
+  the Endpoint should forward traffic to.
+- `default_domain` - (Optional, App only) Whether or not we should create
+  a domain using our default on-aptible.com URL for the Endpoint. Only one
+  Endpoint using a default domain is permitted per App.
+- `endpoint_type` - The type of Endpoint. Valid options are `https` or
+  `tcp`.
+- `internal` - (Optional) Whether the Endpoint should be available
+  exclusively internally. Default is `false`.
+- `managed` - (Optional, App only) Whether or not Aptible should manage
+  the HTTPS certificate for the Endpoint.
+- `platform` - (Optional) Whether to use an [ALB or ELB](https://www.aptible.com/documentation/deploy/reference/apps/endpoints/https-endpoints/alb-elb.html#alb-elb).
+  Supported values are `alb` or `elb`. Default is `elb`.
+- `resource_id` - The ID of the resource you are adding an endpoint to.
+- `resource_type` - The type of resource you are adding an endpoint to.
+  This should be either `app` or `database`.
+- `service_name` - (Required for Apps) The name of the service the Endpoint
+  is for. See main provider documentation for more information on how to
+  determine the sevice name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `endpoint_id` - The unique identifier for this Endpoint
+- `virtual_domain` - The public domain name that would correspond to the
+  certificate served by this domain, if any
+
+## Import
+
+Existing Endpoints can be imported using the Endpoint ID. For example:
+
+```bash
+terraform import aptible_endpoint.example-endpoint <ID>
+```

--- a/docs/resources/replica.md
+++ b/docs/resources/replica.md
@@ -1,0 +1,52 @@
+# Aptible Database Replica Resource
+
+This resource is used to create and manage Database [Replicas and
+Clusters](https://www.aptible.com/documentation/deploy/reference/databases/replication-clustering.html)
+running on Aptible Deploy.
+
+!> Changing the handle of a replica will destroy the existing replica and
+create a new one. It would then have to repopulate its contents from the
+primary database
+
+## Example Usage
+
+```hcl
+resource "aptible_replica" "example_database_replica" {
+    env_id = 123
+    primary_database_id = aptible_database.example_database.database_id
+    handle = "example_database_replica"
+    disk_size = 30
+}
+```
+
+## Argument Reference
+
+- `env_id` - The ID of the environment you would like to deploy your
+  App in. The Environment does not have to be the same as the primary database,
+  but the Environment does have to be in the same
+  [stack](https://www.aptible.com/documentation/deploy/reference/stacks.html)
+  as the primary Database. See main provider documentation for more on how to
+  determine what you should use for `env_id`.
+- `primary_database_id` - The ID of the Database the replica is being
+  created from.
+- `handle` - The handle for the Database. This must be all lower case, and
+  only contain letters, numbers, `-`, `_`, or `.`
+- `container_size` - The size of container used for the Database, in MB
+  of RAM.
+- `disk_size` - The disk size of the Database, in GB.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+- `replica_id` - The unique ID for the replica
+- `default_connection_url` - The default [database credentials](https://www.aptible.com/documentation/deploy/reference/databases/credentials.html)
+  in connection URL format
+
+## Import
+
+Existing Replica can be imported using the Replica ID. For example:
+
+```bash
+terraform import aptible_replica.example-replica <ID>
+```


### PR DESCRIPTION
Closes: https://aptible.atlassian.net/browse/DP-344

This follows the Terraform guidelines for docs on the Registry:
https://www.terraform.io/docs/registry/providers/docs.html

These are ported from our existing documentation on the website,
updated to Markdown, with some additional details added to match
the Terraform Registry conventions.