### PR TITLE
Update endpoint documentation to use process_type

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ can be managed using the `terraform_aptible_endpoint` resource.
 ```hcl
 resource "aptible_endpoint" "EXAMPLE" {
     env_id = ENVIONMENT_ID
-    service_name = "SERVICE_NAME"
+    process_type = "SERVICE_NAME"
     resource_id = aptible_app.APP_HANDLE.app_id
     default_domain = true
     endpoint_type = "https"

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -11,7 +11,7 @@ running on Aptible.
 ```hcl
 resource "aptible_endpoint" "example_endpoint" {
     env_id = 123
-    service_name = "cmd"
+    process_type = "cmd"
     resource_id = aptible_app.example_app.app_id
     default_domain = true
     endpoint_type = "https"
@@ -43,7 +43,7 @@ resource "aptible_endpoint" "example_endpoint" {
 - `resource_id` - The ID of the resource you are adding an endpoint to.
 - `resource_type` - The type of resource you are adding an endpoint to.
   This should be either `app` or `database`.
-- `service_name` - (Required for Apps) The name of the service the Endpoint
+- `process_type` - (Required for Apps) The name of the service the Endpoint
   is for. See main provider documentation for more information on how to
   determine the sevice name.
 


### PR DESCRIPTION
Closes: https://github.com/aptible/terraform-provider-aptible/issues/32

Our documentation referred to a `service_name` field on the endpoints,
but the field is actually `process_type`. This updates the documentation
to accurately reflect the current usage.

If we decide to switch to `service_name` in the future, we can always
switch the docs back when we make the code change.