### PR TITLE
Ignore new darwin arm64 build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: darwin
+      goarch: arm64
     - goos: freebsd
       goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'


### PR DESCRIPTION
The new darwin arm64 target is breaking our deployment builds: 

```
   ⨯ release failed after 425.64s error=failed to build for darwin_arm64: # github.com/aptible/terraform-provider-aptible
/home/travis/.gimme/versions/go1.15.8.linux.amd64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/tmp/go-link-806751987/go.o: file not recognized: File format not recognized
collect2: error: ld returned 1 exit status
```

For now, we ignore that build target. We can upgrade to go1.16 that supports the Apple M1 ARM machines in the future.