### PR TITLE
Mark database urls as sensitive

### DIFF
--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -54,8 +54,9 @@ func resourceDatabase() *schema.Resource {
 				Computed: true,
 			},
 			"default_connection_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"version": {
 				Type:             schema.TypeString,
@@ -67,8 +68,9 @@ func resourceDatabase() *schema.Resource {
 				Computed: true,
 			},
 			"connection_urls": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:      schema.TypeList,
+				Computed:  true,
+				Sensitive: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
Tested using this configuration:

```
data "aptible_environment" "example" {
  handle = "terraform-test-ashley"
}

resource "aptible_app" "example-app" {
  env_id = data.aptible_environment.example.env_id
  handle = "example-app"
  config = {
    "APTIBLE_DOCKER_IMAGE": "httpd:alpine",
    "DATABASE_URL": aptible_database.example-pg-db.default_connection_url,
    "OTHER_DB_URL": aptible_database.example-pg-db.connection_urls[0],
  }
  service {
    process_type = "cmd"
    container_count = 1
    container_memory_limit = 1024
  }
}

resource "aptible_database" "example-pg-db" {
  env_id         = data.aptible_environment.example.env_id
  handle         = "example-pg-db"
  database_type  = "postgresql"
  container_size = 1024
  disk_size      = 10
  version        = "12"
}
```

Gives this output:

```
$ terraform show
# aptible_app.example-app:
resource "aptible_app" "example-app" {
    app_id   = 0000
    config   = {
        "APTIBLE_DOCKER_IMAGE" = "httpd:alpine"
        "DATABASE_URL"         = (sensitive)
        "OTHER_DB_URL"         = (sensitive)
    }
    env_id   = 0000
    git_repo = "git@beta.aptible.com:terraform-test-ashley/example-app.git"
    handle   = "example-app"
    id       = "0000"

    service {
        container_count        = 1
        container_memory_limit = 1024
        process_type           = "cmd"
    }
}

# aptible_database.example-pg-db:
resource "aptible_database" "example-pg-db" {
    connection_urls        = (sensitive value)
    container_size         = 1024
    database_id            = 0000
    database_image_id      = 78
    database_type          = "postgresql"
    default_connection_url = (sensitive value)
    disk_size              = 10
    env_id                 = 0000
    handle                 = "example-pg-db"
    id                     = "0000"
    version                = "12"
}

# data.aptible_environment.example:
data "aptible_environment" "example" {
    env_id = 0000
    handle = "terraform-test-ashley"
    id     = "handle"
}
```


And an example from `terraform applly`:

```
 $ terraform apply

...

  # aptible_app.example-app will be updated in-place
  ~ resource "aptible_app" "example-app" {
      ~ config   = {
          + "OTHER_DB_URL"         = (sensitive)
            # (2 unchanged elements hidden)
        }
        id       = "0000"
        # (4 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```