### PR TITLE
Update Terraform docs

### DIFF
--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -32,6 +32,9 @@ resource "aptible_endpoint" "example_endpoint" {
 - `default_domain` - (Optional, App only) Whether or not we should create
   a domain using our default on-aptible.com URL for the Endpoint. Only one
   Endpoint using a default domain is permitted per App.
+- `domain` - (Optional, App only) Managed TLS Hostname. Required when using
+  Managed TLS (`managed`). Not compatible with Default Domain. Must match
+  hostname of certificate if present.
 - `endpoint_type` - The type of Endpoint. Valid options are `https` or
   `tcp`.
 - `internal` - (Optional) Whether the Endpoint should be available


### PR DESCRIPTION
We don't document `domain` but use it, ran into this in https://aptible.zendesk.com/agent/tickets/40100

Used here: https://github.com/aptible/terraform-provider-aptible/blob/4092435629583997e851d1aa6df985b57befce1f/aptible/resource_endpoint.go#L151
App-Only: https://github.com/aptible/terraform-provider-aptible/blob/4092435629583997e851d1aa6df985b57befce1f/aptible/resource_endpoint.go#L163-L165

I think this is Managed TLS Hostname [based on this](https://github.com/aptible/deploy-api/blob/23190ff1ae0ca45f73e39d3edbd42b09428914e8/app/validators/vhost_validator.rb#L61-L64) but if this is used outside of Managed TLS then I have that wrong and this will need rewritten.

Unrelated, line 45, is `elb` still the correct default?