### PR TITLE
Revert "Ignore new darwin arm64 build target (#42)"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: darwin
-      goarch: arm64
     - goos: freebsd
       goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'


### PR DESCRIPTION
This reverts commit 4092435629583997e851d1aa6df985b57befce1f.