### PR TITLE
Support specifying token as part of provider configuration block

### DIFF
--- a/aptible/provider.go
+++ b/aptible/provider.go
@@ -7,6 +7,13 @@ import (
 
 func Provider() *schema.Provider {
 	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("APTIBLE_ACCESS_TOKEN", nil),
+			},
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"aptible_app":      resourceApp(),
 			"aptible_endpoint": resourceEndpoint(),
@@ -21,7 +28,10 @@ func Provider() *schema.Provider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	client, err := aptible.SetUpClient()
+	attrs := aptible.ClientAttrs{
+		TokenString: d.Get("token").(string),
+	}
+	client, err := aptible.SetUpClient(attrs)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,20 +9,9 @@ that the [cli](https://www.aptible.com/documentation/deploy/cli.html) uses.
 Therefore, you should log into the account you want to use Terraform with using
 the `aptible login` CLI command before running any Terraform commands.
 
-If using in an ephemeral file system or needing something temporary to avoid using the aptible CLI and/or environment variables, you can also use a token in the `required_providers` block to use a token. Take the usual precautions when writing tokens to disk.
-
-```terraform
-terraform {
-  required_providers {
-    aptible = {
-      source  = "aptible/aptible"
-      version = "~>0.1"
-      token = "YOUR TOKEN HERE"
-    }
-  }
-}
-
-```
+If using in an ephemeral file system to avoid using the aptible CLI and/or environment variables, it is possible
+to set the `token` value in the `terraform.required_providers` block (see `examples/demo.tf` for an example). 
+While this is possible, __it is strongly discouraged__.
 
 ### Determining the Environment ID
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,21 @@ that the [cli](https://www.aptible.com/documentation/deploy/cli.html) uses.
 Therefore, you should log into the account you want to use Terraform with using
 the `aptible login` CLI command before running any Terraform commands.
 
+If using in an ephemeral file system or needing something temporary to avoid using the aptible CLI and/or environment variables, you can also use a token in the `required_providers` block to use a token. Take the usual precautions when writing tokens to disk.
+
+```terraform
+terraform {
+  required_providers {
+    aptible = {
+      source  = "aptible/aptible"
+      version = "~>0.1"
+      token = "YOUR TOKEN HERE"
+    }
+  }
+}
+
+```
+
 ### Determining the Environment ID
 
 Each resource managed via Terraform requires an Environment ID specifying which

--- a/examples/demo.tf
+++ b/examples/demo.tf
@@ -6,6 +6,7 @@ terraform {
     aptible = {
       source  = "aptible/aptible"
       version = "~>0.1"
+#      token = <SOME TOKEN HERE>
     }
   }
 }

--- a/examples/demo.tf
+++ b/examples/demo.tf
@@ -6,6 +6,8 @@ terraform {
     aptible = {
       source  = "aptible/aptible"
       version = "~>0.1"
+#      The token may be set here, but proceed with extreme caution. This is not encouraged. You should use the
+#      environment variable `APTIBLE_ACCESS_TOKEN` or the CLI `aptible login`
 #      token = <SOME TOKEN HERE>
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/aptible/go-deploy v0.1.11
+	github.com/aptible/go-deploy v0.1.12-0.20220506040507-9e83156f8141
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect
 	github.com/bflad/tfproviderdocs v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aptible/go-deploy v0.1.11 h1:tOdHoWTgYTlyJ6BubirNIFZsIfnC9LEG56v7/jJdFdk=
 github.com/aptible/go-deploy v0.1.11/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
+github.com/aptible/go-deploy v0.1.12-0.20220506040507-9e83156f8141 h1:gpDH6isamOFahg2PjGVtyyjav11IWV/Q0SmCHOVm2lU=
+github.com/aptible/go-deploy v0.1.12-0.20220506040507-9e83156f8141/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
To use this, add an argument for "token" to the "aptible" provider block:

```terraform
provider "aptible" {
      token = "<<TOKEN>>"
}
```
