### PR TITLE
feat: updated aptible app/db resources to support handle change

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,8 +22,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: darwin
-      goarch: arm64
     - goos: freebsd
       goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -1,6 +1,7 @@
 package aptible
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 
@@ -28,7 +29,6 @@ func resourceApp() *schema.Resource {
 			"handle": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"config": {
 				Type:     schema.TypeMap,
@@ -183,6 +183,18 @@ func resourceAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	err := scaleServices(d, meta)
 	if err != nil {
 		return err
+	}
+
+	handle := d.Get("handle").(string)
+	if d.HasChange("handle") {
+		updates := aptible.AppUpdates{
+			Handle: handle,
+		}
+		log.Printf("Updating handle to %s\n", handle)
+		if err := client.UpdateApp(appID, updates); err != nil {
+			return err
+		}
+		log.Printf(fmt.Sprintf("[WARN] In order for the new app name (%s) to appear in log drain and metric drain destinations, you must restart the app.", handle))
 	}
 
 	return resourceAppRead(d, meta)

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -1,7 +1,6 @@
 package aptible
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 
@@ -194,7 +193,7 @@ func resourceAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		if err := client.UpdateApp(appID, updates); err != nil {
 			return err
 		}
-		log.Printf(fmt.Sprintf("[WARN] In order for the new app name (%s) to appear in log drain and metric drain destinations, you must restart the app.", handle))
+		log.Printf("[WARN] In order for the new app name (%s) to appear in log drain and metric drain destinations, you must restart the app.\n", handle)
 	}
 
 	return resourceAppRead(d, meta)

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -1,7 +1,6 @@
 package aptible
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 
@@ -184,7 +183,7 @@ func resourceDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("handle") {
-		log.Printf(fmt.Sprintf("[WARN] In order for the new database name (%s) to appear in log drain and metric drain destinations, you must restart the database.", handle))
+		log.Printf("[WARN] In order for the new database name (%s) to appear in log drain and metric drain destinations, you must restart the database.\n", handle)
 	}
 
 	return resourceDatabaseRead(d, meta)

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -1,6 +1,7 @@
 package aptible
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 
@@ -28,7 +29,6 @@ func resourceDatabase() *schema.Resource {
 			"handle": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"database_type": {
 				Type:         schema.TypeString,
@@ -157,6 +157,7 @@ func resourceDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
 	databaseID := int64(d.Get("database_id").(int))
 	containerSize := int64(d.Get("container_size").(int))
 	diskSize := int64(d.Get("disk_size").(int))
+	handle := d.Get("handle").(string)
 
 	updates := aptible.DBUpdates{}
 
@@ -168,9 +169,22 @@ func resourceDatabaseUpdate(d *schema.ResourceData, meta interface{}) error {
 		updates.DiskSize = diskSize
 	}
 
+	if d.HasChange("handle") {
+		log.Printf("Updating handle to %s\n", handle)
+		updates.Handle = handle
+	}
+
+	if !d.HasChangesExcept("handle") {
+		updates.OnlyChangingHandle = true
+	}
+
 	err := client.UpdateDatabase(databaseID, updates)
 	if err != nil {
 		return err
+	}
+
+	if d.HasChange("handle") {
+		log.Printf(fmt.Sprintf("[WARN] In order for the new database name (%s) to appear in log drain and metric drain destinations, you must restart the database.", handle))
 	}
 
 	return resourceDatabaseRead(d, meta)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/aptible/go-deploy v0.1.11
+	github.com/aptible/go-deploy v0.1.13
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect
 	github.com/bflad/tfproviderdocs v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/aptible/go-deploy v0.1.11 h1:tOdHoWTgYTlyJ6BubirNIFZsIfnC9LEG56v7/jJdFdk=
-github.com/aptible/go-deploy v0.1.11/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
+github.com/aptible/go-deploy v0.1.13 h1:yJG7sLMNpXCxW9XMa4WOiLzov5UNHp09rXezvxGw1Us=
+github.com/aptible/go-deploy v0.1.13/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
~~DO NOT MERGE until this is merged: https://github.com/aptible/go-deploy/pull/47~~

A fuller format (including warning messages) was explored here - https://github.com/aptible/terraform-provider-aptible/pull/64 but this needs some additional cleanup/review. This PR does not contain the warning messages but does allow for updates. When releasing this we should avoid tagging until the warnings are in from the subsequent PR

The purpose of this PR is to allow handle changes on apps and databases.

To test:

1. Create an app and/or database in terraform
2. Change its handle and redeploy
3. Do the same in no. 2 but change other aspects of the app and ensure multiple types of updates are supported

Proof of function:

1. Created apps:

![image](https://user-images.githubusercontent.com/2961973/186031056-af992357-23d1-4b7e-bccc-dea27313c80d.png)

![image](https://user-images.githubusercontent.com/2961973/186031068-cf711d7b-80a4-4f90-bfd3-84c4346de0eb.png)
![image](https://user-images.githubusercontent.com/2961973/186031083-eb01d475-6479-4fe8-bd82-03d587bb9dd0.png)

2. Updated handles

![image](https://user-images.githubusercontent.com/2961973/186031090-6964b5e1-ee45-4cc5-8a67-a0c328af2e6d.png)

3. Verified changed handles:

![image](https://user-images.githubusercontent.com/2961973/186031109-e86c8088-8d7d-4115-ba19-f42a014b9128.png)
![image](https://user-images.githubusercontent.com/2961973/186031131-7ff293a7-2ba6-471f-8285-25bcf1b39389.png)
