### PR TITLE
fix: dropped double wrapping another non-client error

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -106,7 +106,7 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) error {
 	// TODO: We can check for services scaled to 1 GB/1 container before scaling.
 	err = scaleServices(d, meta)
 	if err != nil {
-		return generateErrorFromClientError(err)
+		return err
 	}
 
 	return resourceAppRead(d, meta)
@@ -193,7 +193,7 @@ func resourceAppUpdate(_ context.Context, d *schema.ResourceData, meta interface
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "There was an error when trying to scale services.",
-			Detail:   generateErrorFromClientError(err).Error(),
+			Detail:   err.Error(),
 		})
 		return diags
 	}


### PR DESCRIPTION
N/A

---

I was able to test this by dropping the validator func, forcing an incorrect value causing a backend error to bubble up. Dropping double wrapping. Underlying error should not be impacted and correctly reports:

<img width="896" alt="image" src="https://user-images.githubusercontent.com/2961973/189932094-e6529e57-455e-4a34-b424-c3f3a258d1eb.png">

<img width="1454" alt="image" src="https://user-images.githubusercontent.com/2961973/189932124-32635b2a-d69f-486b-8f06-30a492499621.png">
