### PR TITLE
fix: updated endpoint resource to use ForceNew prompting deletion/recreation when changing internal field

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -69,6 +69,7 @@ func resourceEndpoint() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"container_port": {
 				Type:         schema.TypeInt,

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -38,7 +38,7 @@ resource "aptible_endpoint" "example_endpoint" {
 - `endpoint_type` - The type of Endpoint. Valid options are `https` or
   `tcp`.
 - `internal` - (Optional) Whether the Endpoint should be available
-  exclusively internally. Default is `false`.
+  exclusively internally. Changing this can be a destructive operation; when this is changed the resource will be destroyed and recreated. Default is `false`.
 - `managed` - (Optional, App only) Whether or not Aptible should manage
   the HTTPS certificate for the Endpoint.
 - `platform` - (Optional) Whether to use an [ALB or ELB](https://www.aptible.com/documentation/deploy/reference/apps/endpoints/https-endpoints/alb-elb.html#alb-elb).


### PR DESCRIPTION
Our API does not support switching endpoints between internal and external. This is a good decision that supports avoiding accidental internal => external conversions.

We should instead set ForceNew: true on that field.

---

Created an endpoint that was internal. (`internal = true`)

<img width="411" alt="image" src="https://user-images.githubusercontent.com/2961973/189995702-2968cd41-92b3-46ca-b6f5-5e22bfdfc3c1.png">

Then updated endpoint to external (`internal = false`), which forced a prompt and deletes/recreates:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/2961973/189996868-0a2a78b9-2439-4c60-884c-f69a515772df.png">

<img width="589" alt="image" src="https://user-images.githubusercontent.com/2961973/189997683-5940d781-eb8c-4303-abff-a2bc98c6cd3e.png">