### PR TITLE
fix: removed double-wrapped error on database

### DIFF
--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -204,7 +204,7 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "There was an error when trying to retrieve the updated state of the database.",
-			Detail:   generateErrorFromClientError(err).Error(),
+			Detail:   err.Error(),
 		})
 	}
 


### PR DESCRIPTION
This was missed and is the only other location a client call's error was not wrapped. 

This has no impact except giving an unhelpful error message (which was already the case)