### PR TITLE
[Endpoint] Add `domain` validation for managed endpoints

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -154,6 +154,9 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	if defaultDomain && managed {
 		return fmt.Errorf("do not specify Managed HTTPS if using the Default Domain")
 	}
+	if managed && domain == "" {
+		return fmt.Errorf("Managed endpoints must specify a domain")
+	}
 	if defaultDomain && domain != "" {
 		return fmt.Errorf("cannot specify domain when using Default Domain")
 	}


### PR DESCRIPTION
According to [the docs](https://registry.terraform.io/providers/aptible/aptible/latest/docs/resources/endpoint#domain), if `managed = true` then `domain` must also be set but there is no validation for this. This PR adds that validationg