### PR TITLE
fix: fix errors found in regression of some operation errors bubbling up

### DIFF
--- a/aptible/client_utils.go
+++ b/aptible/client_utils.go
@@ -48,9 +48,6 @@ func generateErrorFromClientError(abstractedError interface{}) error {
 			"Error without a valid payload: ", abstractedError, "\n",
 		)
 	} else if out.Payload.Code == nil || out.Payload.Error == nil {
-		if err != nil {
-			errorString = fmt.Sprintf("- %s", err.Error())
-		}
 		if out.Payload.Code != nil && *out.Payload.Code >= 400 {
 			errorString += fmt.Sprintf(" status code (%d)", *out.Payload.Code)
 		}

--- a/aptible/client_utils.go
+++ b/aptible/client_utils.go
@@ -31,6 +31,7 @@ func generateErrorFromClientError(abstractedError interface{}) error {
 		}
 	}()
 
+	log.Println("[ERROR] error received and being processed", abstractedError)
 	data, err := json.Marshal(&abstractedError)
 	if err != nil {
 		return fmt.Errorf("Unable to properly decode error in marshal from client - %s\n", err.Error())
@@ -41,31 +42,40 @@ func generateErrorFromClientError(abstractedError interface{}) error {
 		return fmt.Errorf("Unable to properly decode error in unmarshal from client - %s\n", err.Error())
 	}
 
-	if out.Payload.Code == nil || out.Payload.Error == nil {
-		var errString string
+	// payload is a pointer and can be nil, but we don't have all our information from a http code, so we construct it
+	if out.Payload == nil {
+		errorString = fmt.Sprint(
+			"Error without a valid payload: ", abstractedError, "\n",
+		)
+	} else if out.Payload.Code == nil || out.Payload.Error == nil {
 		if err != nil {
-			errString = fmt.Sprintf("- %s", err.Error())
+			errorString = fmt.Sprintf("- %s", err.Error())
 		}
 		if out.Payload.Code != nil && *out.Payload.Code >= 400 {
-			errString += fmt.Sprintf(" status code (%d)", *out.Payload.Code)
+			errorString += fmt.Sprintf(" status code (%d)", *out.Payload.Code)
 		}
+
 		if out.Payload.Error != nil && len(*out.Payload.Error) > 0 {
-			errString += fmt.Sprintf(" error (%s)", *out.Payload.Error)
+			errorString += fmt.Sprintf(" error (%s)", *out.Payload.Error)
 		}
+
 		if out.Payload.Message != nil && len(*out.Payload.Message) > 0 {
-			errString += fmt.Sprintf(" error message (%s)", *out.Payload.Message)
+			errorString += fmt.Sprintf(" error message (%s)", *out.Payload.Message)
 		}
+
 		return fmt.Errorf(
-			"unable to properly decode error (missing fields to properly generate error)%s",
-			errString,
+			"unable to properly decode error (missing fields to properly generate error) - %s\n",
+			errorString,
+		)
+	} else {
+		// payload is not nil, and fully populated
+		errorString = fmt.Sprintf(
+			"Error with status code: %d. %s - %s\n",
+			*out.Payload.Code,
+			*out.Payload.Error,
+			*out.Payload.Message,
 		)
 	}
-	errorString = fmt.Sprintf(
-		"Error with status code: %d. %s - %s\n",
-		*out.Payload.Code,
-		*out.Payload.Error,
-		*out.Payload.Message,
-	)
 
 	return errors.New(errorString)
 }

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -100,8 +100,12 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := generateErrorFromClientError(tt.args.abstractedError)
-			wantErr := err == nil
-			if wantErr == tt.wantErr && tt.errorBody != err.Error() {
+			gotErr := err != nil
+			if tt.wantErr != gotErr {
+				t.Errorf("wanted an error (tt.wantErr), but did not get an error (gotErr) OR didn't want an error" +
+					"and got an error!")
+			}
+			if tt.wantErr == gotErr && tt.errorBody != err.Error() {
 				t.Errorf("generateErrorFromClientError() error = %v, wantErr %v, errorBody %s", err, tt.wantErr, tt.errorBody)
 			}
 		})

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -1,6 +1,7 @@
 package aptible
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -55,7 +56,7 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 				},
 			},
 			wantErr:   true,
-			errorBody: "unable to properly decode error (missing fields to properly generate error) error (not_found) error message (resource not found)",
+			errorBody: "unable to properly decode error (missing fields to properly generate error) -  error (not_found) error message (resource not found)\n",
 		},
 		{
 			name: "return a pre-baked error when error code not found",
@@ -69,15 +70,15 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 				},
 			},
 			wantErr:   true,
-			errorBody: "unable to properly decode error (missing fields to properly generate error) status code (400) error message (resource not found)",
+			errorBody: "unable to properly decode error (missing fields to properly generate error) -  status code (400) error message (resource not found)\n",
 		},
 		{
-			name: "return a marshalable error (if server sends back garbled response)",
+			name: "return a marshalable error with a nil payload should break early",
 			args: args{
 				abstractedError: nil,
 			},
 			wantErr:   true,
-			errorBody: "Unable to properly decode error in marshal from client - json: cannot unmarshal string into Go value of type aptible.clientError\n",
+			errorBody: "Error without a valid payload: <nil>\n",
 		},
 		{
 			name: "return a unmarshalable error (but unmarshalable into expected type)",
@@ -86,6 +87,14 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 			},
 			wantErr:   true,
 			errorBody: "Unable to properly decode error in unmarshal from client - json: cannot unmarshal string into Go value of type aptible.clientError\n",
+		},
+		{
+			name: "return a unmarshalable error (but unmarshalable into expected type)",
+			args: args{
+				abstractedError: errors.New("any old error that is not json type"),
+			},
+			wantErr:   true,
+			errorBody: "Error without a valid payload: any old error that is not json type\n",
 		},
 	}
 	for _, tt := range tests {

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -105,7 +105,7 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 				t.Errorf("wanted an error (tt.wantErr), but did not get an error (gotErr) OR didn't want an error" +
 					"and got an error!")
 			}
-			if tt.wantErr == gotErr && tt.errorBody != err.Error() {
+			if gotErr && tt.errorBody != err.Error() {
 				t.Errorf("generateErrorFromClientError() error = %v, wantErr %v, errorBody %s", err, tt.wantErr, tt.errorBody)
 			}
 		})

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -99,7 +99,9 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := generateErrorFromClientError(tt.args.abstractedError); (err != nil) == tt.wantErr && tt.errorBody != err.Error() {
+			err := generateErrorFromClientError(tt.args.abstractedError)
+			wantErr := err == nil
+			if wantErr == tt.wantErr && tt.errorBody != err.Error() {
 				t.Errorf("generateErrorFromClientError() error = %v, wantErr %v, errorBody %s", err, tt.wantErr, tt.errorBody)
 			}
 		})

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -81,7 +81,7 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 			errorBody: "Error without a valid payload: <nil>\n",
 		},
 		{
-			name: "return a unmarshalable error (but unmarshalable into expected type)",
+			name: "return a unmarshalable error (invalid json)",
 			args: args{
 				abstractedError: "{",
 			},
@@ -89,7 +89,7 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 			errorBody: "Unable to properly decode error in unmarshal from client - json: cannot unmarshal string into Go value of type aptible.clientError\n",
 		},
 		{
-			name: "return a unmarshalable error (but unmarshalable into expected type)",
+			name: "return a marshalable error but without a payload (regular errors, non-swagger client)",
 			args: args{
 				abstractedError: errors.New("any old error that is not json type"),
 			},


### PR DESCRIPTION
This should fix possible errors when non-swagger errors bubble up within the client. 

<img width="826" alt="image" src="https://user-images.githubusercontent.com/2961973/193317492-1b2089e2-fb23-42d0-8bc2-1a62f60546da.png">

This was handled for all errors that are non-client non-swagger errors and is very specific when the `Payload` is nil and wasn't accounted for in a unit test.