### PR TITLE
Add helper to convert validation errors to warnings

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -72,7 +72,7 @@ func resourceApp() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "m4",
-							ValidateFunc: validation.StringInSlice(validContainerProfiles, false),
+							ValidateFunc: errorsToWarnings(validation.StringInSlice(validContainerProfiles, false)),
 						},
 					},
 				},

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -48,7 +48,7 @@ func resourceDatabase() *schema.Resource {
 			"container_profile": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice(validContainerProfiles, false),
+				ValidateFunc: errorsToWarnings(validation.StringInSlice(validContainerProfiles, false)),
 				Default:      "m4",
 			},
 			"disk_size": {

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -42,6 +42,7 @@ func validateURL(i interface{}, k string) (_ []string, errors []error) {
 	return
 }
 
+// lintignore:SA1019
 func errorsToWarnings(validator schema.SchemaValidateFunc) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) ([]string, []error) {
 		warns, errs := validator(i, k)

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -39,3 +39,16 @@ func validateURL(i interface{}, k string) (_ []string, errors []error) {
 
 	return
 }
+
+func errorsToWarnings(validator func(i interface{}, k string) ([]string, []error)) func(i interface{}, k string) ([]string, []error) {
+	return func(i interface{}, k string) ([]string, []error) {
+		warns, errs := validator(i, k)
+		for _, err := range errs {
+			if err != nil {
+				warns = append(warns, err.Error())
+			}
+		}
+
+		return warns, nil
+	}
+}

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -3,6 +3,8 @@ package aptible
 import (
 	"fmt"
 	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // Modified validation.IsURLWithScheme to simply check for a URL that has any scheme and a host.
@@ -40,7 +42,7 @@ func validateURL(i interface{}, k string) (_ []string, errors []error) {
 	return
 }
 
-func errorsToWarnings(validator func(i interface{}, k string) ([]string, []error)) func(i interface{}, k string) ([]string, []error) {
+func errorsToWarnings(validator schema.SchemaValidateFunc) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) ([]string, []error) {
 		warns, errs := validator(i, k)
 		for _, err := range errs {

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -42,7 +42,7 @@ func validateURL(i interface{}, k string) (_ []string, errors []error) {
 	return
 }
 
-// lintignore:SA1019
+// nolint:staticcheck
 func errorsToWarnings(validator schema.SchemaValidateFunc) schema.SchemaValidateFunc {
 	return func(i interface{}, k string) ([]string, []error) {
 		warns, errs := validator(i, k)

--- a/aptible/validation_test.go
+++ b/aptible/validation_test.go
@@ -65,6 +65,7 @@ func TestValidateURL(t *testing.T) {
 
 func Test_errorsToWarnings(t *testing.T) {
 	type args struct {
+		// lintignore:SA1019
 		validator schema.SchemaValidateFunc
 	}
 	tests := []struct {

--- a/aptible/validation_test.go
+++ b/aptible/validation_test.go
@@ -65,7 +65,7 @@ func TestValidateURL(t *testing.T) {
 
 func Test_errorsToWarnings(t *testing.T) {
 	type args struct {
-		// lintignore:SA1019
+		// nolint:staticcheck
 		validator schema.SchemaValidateFunc
 	}
 	tests := []struct {

--- a/aptible/validation_test.go
+++ b/aptible/validation_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestValidateURL(t *testing.T) {
@@ -63,7 +65,7 @@ func TestValidateURL(t *testing.T) {
 
 func Test_errorsToWarnings(t *testing.T) {
 	type args struct {
-		validator func(i interface{}, k string) ([]string, []error)
+		validator schema.SchemaValidateFunc
 	}
 	tests := []struct {
 		name       string

--- a/aptible/validation_test.go
+++ b/aptible/validation_test.go
@@ -60,3 +60,45 @@ func TestValidateURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_errorsToWarnings(t *testing.T) {
+	type args struct {
+		validator func(i interface{}, k string) ([]string, []error)
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       []string
+		wantErrors []error
+	}{
+		{
+			name: "appends errors to warnings",
+			args: args{
+				validator: func(_ interface{}, _ string) ([]string, []error) {
+					return []string{"warning 1", "warning 2"}, []error{fmt.Errorf("error 1"), fmt.Errorf("error 2")}
+				},
+			},
+			want: []string{"warning 1", "warning 2", "error 1", "error 2"},
+		},
+		{
+			name: "skips nil errors",
+			args: args{
+				validator: func(_ interface{}, _ string) ([]string, []error) {
+					return []string{"warning 1", "warning 2"}, []error{fmt.Errorf("error 1"), nil, fmt.Errorf("error 2")}
+				},
+			},
+			want: []string{"warning 1", "warning 2", "error 1", "error 2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWarnings, gotErrors := errorsToWarnings(tt.args.validator)(nil, "don't worry about it")
+			if !reflect.DeepEqual(gotWarnings, tt.want) {
+				t.Errorf("warnings = %v, want %v", gotWarnings, tt.want)
+			}
+			if !reflect.DeepEqual(gotErrors, tt.wantErrors) {
+				t.Errorf("errors = %v, want %v", gotErrors, tt.wantErrors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow up to #79. This is a relatively simple solution for allowing additional container profiles to be supported without having to upgrade the provider. Unfortunately, terraform doesn't provide a way to check for warnings using their testing framework so I can't test for them.

<img width="650" alt="Screen Shot 2022-10-14 at 15 06 25" src="https://user-images.githubusercontent.com/48493233/195924601-d274f6c7-a5fc-433d-b821-1fb97e52aff7.png">