### PR TITLE
Fix issue with scaling when it isn't necessary

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -260,10 +260,11 @@ func scaleServices(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*aptible.Client)
 	appID := int64(d.Get("app_id").(int))
 
+	// If there are no changes to services, there's no reason to scale
 	if !d.HasChange("service") {
 		return nil
 	}
-	
+
 	// If we're changing existing services, be sure we're using the "new" service definitions and only
 	// try to scale ones that actually change
 	log.Println("Detected change in services")

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -260,15 +260,15 @@ func scaleServices(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*aptible.Client)
 	appID := int64(d.Get("app_id").(int))
 
-	services := d.Get("service").(*schema.Set).List()
-
+	if !d.HasChange("service") {
+		return nil
+	}
+	
 	// If we're changing existing services, be sure we're using the "new" service definitions and only
 	// try to scale ones that actually change
-	if d.HasChange("service") {
-		log.Println("Detected change in services")
-		oldService, newService := d.GetChange("service")
-		services = newService.(*schema.Set).Difference(oldService.(*schema.Set)).List()
-	}
+	log.Println("Detected change in services")
+	oldService, newService := d.GetChange("service")
+	services := newService.(*schema.Set).Difference(oldService.(*schema.Set)).List()
 
 	for _, s := range services {
 		serviceInterface := s.(map[string]interface{})


### PR DESCRIPTION
If the App's state changed but none of the services did, every service was being scaled to the existing container count, size, and profile.