### PR TITLE
fix: made env values sensitive so they're masked

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -32,11 +32,11 @@ func resourceApp() *schema.Resource {
 				Required: true,
 			},
 			"config": {
-				Type:     schema.TypeMap,
-				Optional: true,
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Sensitive: true,
 				Elem: &schema.Schema{
-					Type:      schema.TypeString,
-					Sensitive: true,
+					Type: schema.TypeString,
 				},
 			},
 			"app_id": {

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -35,7 +35,8 @@ func resourceApp() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:      schema.TypeString,
+					Sensitive: true,
 				},
 			},
 			"app_id": {


### PR DESCRIPTION
Proof of function with latest changes:

<img width="372" alt="image" src="https://user-images.githubusercontent.com/2961973/222205595-f96c27e7-f596-4c1a-bd55-c4a889cf4542.png">

---

In some cases users will use sensitive values in the `config` thus printing on their print out, we want to validate that this does not reveal those values regardless of circumstance.