### PR TITLE
sc-16403 - added container_ports support to endpoints in array form

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -71,6 +71,12 @@ func resourceEndpoint() *schema.Resource {
 				Default:  false,
 				ForceNew: true,
 			},
+			"container_ports": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				Elem:
+				ValidateFunc: validation.IntBetween(1, 65535),
+			},
 			"container_port": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -123,9 +129,15 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	resourceType := d.Get("resource_type").(string)
 	interfaceSlice := d.Get("ip_filtering").([]interface{})
 	ipWhitelist, _ := aptible.MakeStringSlice(interfaceSlice)
+	interfaceContainerPortsSlice := d.Get("container_ports").([]interface{})
+	containerPorts, _ := aptible.MakeStringSlice(interfaceContainerPortsSlice)
 	defaultDomain := d.Get("default_domain").(bool)
 	managed := d.Get("managed").(bool)
 	domain := d.Get("domain").(string)
+	containerPort, _ := (d.Get("container_port").(int))
+	if containerPort != nil && containerPorts != nil {
+		return fmt.Errorf("do not specify container ports AND container port (see terraform docs)")
+	}
 
 	if defaultDomain && managed {
 		return fmt.Errorf("do not specify Managed HTTPS if using the Default Domain")

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -137,7 +137,7 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	managed := d.Get("managed").(bool)
 	domain := d.Get("domain").(string)
 	containerPort, _ := (d.Get("container_port").(int))
-	if containerPort != 0 && containerPorts != nil {
+	if containerPort != 0 && len(containerPorts) != 0 {
 		return fmt.Errorf("do not specify container ports AND container port (see terraform docs)")
 	}
 
@@ -271,6 +271,10 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	ipWhitelist, _ := aptible.MakeStringSlice(interfaceSlice)
 	interfaceContainerPortsSlice := d.Get("container_ports").([]interface{})
 	containerPorts, _ := aptible.MakeInt64Slice(interfaceContainerPortsSlice)
+	containerPort, _ := (d.Get("container_port").(int))
+	if containerPort != 0 && len(containerPorts) != 0 {
+		return fmt.Errorf("do not specify container ports AND container port (see terraform docs)")
+	}
 
 	updates := aptible.EndpointUpdates{
 		ContainerPort:  int64(d.Get("container_port").(int)),

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -75,9 +75,9 @@ func resourceEndpoint() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeInt,
+					Type:         schema.TypeInt,
+					ValidateFunc: validation.IntBetween(1, 65535),
 				},
-				ValidateDiagFunc: validateContainerPorts,
 			},
 			"container_port": {
 				Type:         schema.TypeInt,

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -137,8 +137,12 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 		err = multierror.Append(err, fmt.Errorf("do not specify container ports AND container port (see terraform docs)"))
 	}
 
+	if containerPort != 0 && (endpointType == "tcp" || endpointType == "tls") {
+		err = multierror.Append(err, fmt.Errorf("do not specify container port with a tls or tcp endpoint"))
+	}
+
 	// container ports can only be used with tls/tcp
-	if len(containerPorts) != 0 && (endpointType == "https" || endpointType == "HTTPS") {
+	if len(containerPorts) != 0 && (endpointType == "https") {
 		err = multierror.Append(err, fmt.Errorf("do not specify container ports with https endpoint (see terraform docs)"))
 	}
 

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -226,6 +226,14 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 				ExpectError: regexp.MustCompile(`expected container_port to be in the range \(1 \- 65535\)`),
 			},
 			{
+				Config:      testAccAptibleEndpointInvalidContainerPortOnTcp(),
+				ExpectError: regexp.MustCompile(`do not specify container port with a tls or tcp endpoint`),
+			},
+			{
+				Config:      testAccAptibleEndpointInvalidContainerPortOnTls(),
+				ExpectError: regexp.MustCompile(`do not specify container port with a tls or tcp endpoint`),
+			},
+			{
 				Config:      testAccAptibleEndpointInvalidContainerPorts(),
 				ExpectError: regexp.MustCompile(`expected container_ports.0 to be in the range \(1 \- 65535\)`),
 			},
@@ -499,6 +507,40 @@ resource "aptible_endpoint" "test" {
 	platform = "alb"
 	managed = true
 	container_port = 99999
+	}`, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidContainerPortOnTcp() string {
+	output := fmt.Sprintf(`
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	endpoint_type = "tcp"
+	resource_id = 1
+	resource_type = "app"
+	process_type = "cmd"
+	default_domain = false
+	platform = "alb"
+	managed = true
+	container_port = 3000
+	}`, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidContainerPortOnTls() string {
+	output := fmt.Sprintf(`
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	endpoint_type = "tls"
+	resource_id = 1
+	resource_type = "app"
+	process_type = "cmd"
+	default_domain = false
+	platform = "alb"
+	managed = true
+	container_port = 3000
 	}`, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -181,6 +181,14 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 				Config:      testAccAptibleEndpointInvalidDomain(),
 				ExpectError: regexp.MustCompile(`managed endpoints must specify a domain`),
 			},
+			{
+				Config:      testAccAptibleEndpointInvalidContainerPort(),
+				ExpectError: regexp.MustCompile(`expected container_port to be in the range \(1 \- 65535\)`),
+			},
+			{
+				Config:      testAccAptibleEndpointInvalidContainerPorts(),
+				ExpectError: regexp.MustCompile(`expected container_ports.0 to be in the range \(1 \- 65535\)`),
+			},
 		},
 	})
 }
@@ -396,6 +404,38 @@ resource "aptible_endpoint" "test" {
 	platform = "alb"
 	managed = true
 	domain = ""
+	}`, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidContainerPort() string {
+	output := fmt.Sprintf(`
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	resource_id = 1
+	resource_type = "app"
+	process_type = "cmd"
+	default_domain = false
+	platform = "alb"
+	managed = true
+	container_port = 99999
+	}`, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidContainerPorts() string {
+	output := fmt.Sprintf(`
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	resource_id = 1
+	resource_type = "app"
+	process_type = "cmd"
+	default_domain = false
+	platform = "alb"
+	managed = true
+	container_ports = [99999]
 	}`, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -189,6 +189,14 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 				Config:      testAccAptibleEndpointInvalidContainerPorts(),
 				ExpectError: regexp.MustCompile(`expected container_ports.0 to be in the range \(1 \- 65535\)`),
 			},
+			{
+				Config:      testAccAptibleEndpointInvalidContainerPortsOnHttp(),
+				ExpectError: regexp.MustCompile(`do not specify container ports with https endpoint`),
+			},
+			{
+				Config:      testAccAptibleEndpointInvalidMultipleContainerPortFields(),
+				ExpectError: regexp.MustCompile(`do not specify container ports AND container port`),
+			},
 		},
 	})
 }
@@ -436,6 +444,41 @@ resource "aptible_endpoint" "test" {
 	platform = "alb"
 	managed = true
 	container_ports = [99999]
+	}`, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidContainerPortsOnHttp() string {
+	output := fmt.Sprintf(`
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	endpoint_type = "https"
+	resource_id = 1
+	resource_type = "app"
+	process_type = "cmd"
+	default_domain = false
+	platform = "alb"
+	managed = true
+	container_ports = [3000]
+	}`, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidMultipleContainerPortFields() string {
+	output := fmt.Sprintf(`
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	endpoint_type = "tcp"
+	resource_id = 1
+	resource_type = "app"
+	process_type = "cmd"
+	default_domain = false
+	platform = "alb"
+	managed = true
+	container_port = 3000
+	container_ports = [3000]
 	}`, testEnvironmentId)
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Modified validation.IsURLWithScheme to simply check for a URL that has any scheme and a host.
@@ -43,31 +41,6 @@ func validateURL(i interface{}, k string) (_ []string, errors []error) {
 	}
 
 	return
-}
-
-func validateContainerPorts(i interface{}, _ cty.Path) diag.Diagnostics {
-	var diags diag.Diagnostics
-	min, max := int64(1), int64(65536)
-	v, ok := i.([]int64)
-	if !ok {
-		diags = append(
-			diags,
-			diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("expected type of %q to be int64[]", "port"),
-			})
-	}
-
-	for _, port := range v {
-		if port < min || port > max {
-			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("expected %s to be in the range (%d - %d), got %d", "port", min, max, v),
-			})
-		}
-	}
-
-	return diags
 }
 
 // nolint:staticcheck

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Modified validation.IsURLWithScheme to simply check for a URL that has any scheme and a host.
@@ -41,6 +43,31 @@ func validateURL(i interface{}, k string) (_ []string, errors []error) {
 	}
 
 	return
+}
+
+func validateContainerPorts(i interface{}, _ cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+	min, max := int64(1), int64(65536)
+	v, ok := i.([]int64)
+	if !ok {
+		diags = append(
+			diags,
+			diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("expected type of %q to be int64[]", "port"),
+			})
+	}
+
+	for _, port := range v {
+		if port < min || port > max {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("expected %s to be in the range (%d - %d), got %d", "port", min, max, v),
+			})
+		}
+	}
+
+	return diags
 }
 
 // nolint:staticcheck

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -14,6 +14,8 @@ running on Aptible.
 resource "aptible_endpoint" "example" {
   env_id         = data.aptible_environment.example.env_id
   resource_id    = aptible_app.example.app_id
+  # alternatively, one could also set "container_ports = [3000,3001]"
+  container_port = 3000 
   resource_type  = "app"
   process_type   = "cmd"
   default_domain = true
@@ -69,7 +71,10 @@ resource "aws_route53_record" "dns01" {
   is for. See main provider documentation for more information on how to
   determine the sevice name.
 - `container_port` - (Optional, App only) The port on the container which
-  the Endpoint should forward traffic to.
+  the Endpoint should forward traffic to. Mutually exclusive from `container_ports`.
+- `container_ports` - (Optional, App only) The ports in array form on the container which
+  the Endpoint should forward traffic to. Mutually exclusive from `container_port`. Multiple
+  ports are only allowed on a `tcp` or `tls` endpoint.
 - `default_domain` - (App only, Default: false) If the Endpoint should use the
   App's default `on-aptible.com` domain. Only one Endpoint per App can use the
   default domain. Cannot be used with `managed`.

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -71,10 +71,11 @@ resource "aws_route53_record" "dns01" {
   is for. See main provider documentation for more information on how to
   determine the sevice name.
 - `container_port` - (Optional, App only) The port on the container which
-  the Endpoint should forward traffic to. Mutually exclusive from `container_ports`.
+  the Endpoint should forward traffic to. Mutually exclusive from `container_ports`. 
+  You should use this for `https` endpoints.
 - `container_ports` - (Optional, App only) The ports in array form on the container which
-  the Endpoint should forward traffic to. Mutually exclusive from `container_port`. Multiple
-  ports are only allowed on a `tcp` or `tls` endpoint.
+  the Endpoint should forward traffic to. Mutually exclusive from `container_port`.
+  Multiple container ports are only allowed on a `tcp` or `tls` endpoint.
 - `default_domain` - (App only, Default: false) If the Endpoint should use the
   App's default `on-aptible.com` domain. Only one Endpoint per App can use the
   default domain. Cannot be used with `managed`.

--- a/go.mod
+++ b/go.mod
@@ -65,5 +65,3 @@ require (
 	google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84 // indirect
 	mvdan.cc/unparam v0.0.0-20210520122750-2ac67f130a88 // indirect
 )
-
-replace github.com/aptible/go-deploy => ../../work/go-deploy

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/aptible/go-deploy v0.4.2-0.20230721225144-5560e8fcf2fe
+	github.com/aptible/go-deploy v0.5.0
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect
 	github.com/bflad/tfproviderdocs v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/aptible/go-deploy v0.4.1
+	github.com/aptible/go-deploy v0.4.2-0.20230721225144-5560e8fcf2fe
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect
 	github.com/bflad/tfproviderdocs v0.9.1
@@ -65,3 +65,5 @@ require (
 	google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84 // indirect
 	mvdan.cc/unparam v0.0.0-20210520122750-2ac67f130a88 // indirect
 )
+
+replace github.com/aptible/go-deploy => ../../work/go-deploy

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/aptible/go-deploy v0.5.0 h1:fVqCoyFm3oGifyUyyoY9dJUxW3bwhgu9C2oTREXCiSI=
+github.com/aptible/go-deploy v0.5.0/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -115,10 +115,6 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/aptible/go-deploy v0.4.1 h1:diop5W2ZwvK8mO2f2lWdVp8ExN7IClEbB9svYYCnfZk=
-github.com/aptible/go-deploy v0.4.1/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
-github.com/aptible/go-deploy v0.4.2-0.20230721225144-5560e8fcf2fe h1:YbfOZrFEHreV2NQFnRpGFvrR9dMzPTjU3enBhXLV5K4=
-github.com/aptible/go-deploy v0.4.2-0.20230721225144-5560e8fcf2fe/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aptible/go-deploy v0.4.1 h1:diop5W2ZwvK8mO2f2lWdVp8ExN7IClEbB9svYYCnfZk=
 github.com/aptible/go-deploy v0.4.1/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
+github.com/aptible/go-deploy v0.4.2-0.20230721225144-5560e8fcf2fe h1:YbfOZrFEHreV2NQFnRpGFvrR9dMzPTjU3enBhXLV5K4=
+github.com/aptible/go-deploy v0.4.2-0.20230721225144-5560e8fcf2fe/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Note - I used `caddy` as it has multiple exposed ports on their base docker image https://hub.docker.com/_/caddy for integration tests

This correctly will validate (`https` not allowed this, `container_port` and `container_ports` being mutually exclusive and/or only usable for tcp/tls):

![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/7d0359f7-a10f-4901-9528-95c8060e3253)
![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/b0f3f8a6-695d-4cf5-81af-4aab82e3d867)

It will also correctly create:

![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/d7bc8d9a-bb6f-4f89-92a5-1eb3e3f2edb4)
![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/9ce9e7eb-a7db-4348-8f28-cffdaaa52d30)
![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/9a5a65e6-fbc5-4017-a206-a03de9f980d3)

---

Integration tests and unit tests also pass:

![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/ee9c7960-af4c-4192-9168-6234afeafa1d)

---

This is needed for merge: https://github.com/aptible/go-deploy/pull/63