### PR TITLE
fix: correct zero value behavior for container ports / container port (as on release)

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -214,10 +214,6 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		Default:        defaultDomain,
 		Acme:           managed,
 	}
-	if len(containerPorts) > 0 {
-		// zero values for arrays give non-deterministic responses from backend
-		attrs.ContainerPorts = containerPorts
-	}
 	if domain != "" {
 		attrs.UserDomain = domain
 	}
@@ -305,10 +301,6 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 		ContainerPorts: containerPorts,
 		IPWhitelist:    ipWhitelist,
 		Platform:       d.Get("platform").(string),
-	}
-	if len(containerPorts) > 0 {
-		// zero values for arrays give non-deterministic responses from backend
-		updates.ContainerPorts = containerPorts
 	}
 
 	err := client.UpdateEndpoint(endpointID, updates)

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -214,7 +214,7 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		Default:        defaultDomain,
 		Acme:           managed,
 	}
-	if containerPorts != nil && len(containerPorts) > 0 {
+	if len(containerPorts) > 0 {
 		// zero values for arrays give non-deterministic responses from backend
 		attrs.ContainerPorts = containerPorts
 	}
@@ -306,7 +306,7 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 		IPWhitelist:    ipWhitelist,
 		Platform:       d.Get("platform").(string),
 	}
-	if containerPorts != nil && len(containerPorts) > 0 {
+	if len(containerPorts) > 0 {
 		// zero values for arrays give non-deterministic responses from backend
 		updates.ContainerPorts = containerPorts
 	}

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -174,13 +174,10 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		Platform:      d.Get("platform").(string),
 		Default:       defaultDomain,
 		Acme:          managed,
-<<<<<<< Updated upstream
-=======
 	}
 	if containerPorts != nil && len(containerPorts) > 0 {
 		// zero values for arrays give non-deterministic responses from backend
 		attrs.ContainerPorts = containerPorts
->>>>>>> Stashed changes
 	}
 	if domain != "" {
 		attrs.UserDomain = domain
@@ -265,13 +262,10 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 		ContainerPort: int64(d.Get("container_port").(int)),
 		IPWhitelist:   ipWhitelist,
 		Platform:      d.Get("platform").(string),
-<<<<<<< Updated upstream
-=======
 	}
 	if containerPorts != nil && len(containerPorts) > 0 {
 		// zero values for arrays give non-deterministic responses from backend
 		updates.ContainerPorts = containerPorts
->>>>>>> Stashed changes
 	}
 
 	err := client.UpdateEndpoint(endpointID, updates)

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -174,6 +174,13 @@ func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		Platform:      d.Get("platform").(string),
 		Default:       defaultDomain,
 		Acme:          managed,
+<<<<<<< Updated upstream
+=======
+	}
+	if containerPorts != nil && len(containerPorts) > 0 {
+		// zero values for arrays give non-deterministic responses from backend
+		attrs.ContainerPorts = containerPorts
+>>>>>>> Stashed changes
 	}
 	if domain != "" {
 		attrs.UserDomain = domain
@@ -258,6 +265,13 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 		ContainerPort: int64(d.Get("container_port").(int)),
 		IPWhitelist:   ipWhitelist,
 		Platform:      d.Get("platform").(string),
+<<<<<<< Updated upstream
+=======
+	}
+	if containerPorts != nil && len(containerPorts) > 0 {
+		// zero values for arrays give non-deterministic responses from backend
+		updates.ContainerPorts = containerPorts
+>>>>>>> Stashed changes
 	}
 
 	err := client.UpdateEndpoint(endpointID, updates)

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -50,7 +50,48 @@ func TestAccResourceEndpoint_customDomain(t *testing.T) {
 	})
 }
 
+<<<<<<< Updated upstream
 func TestAccResourceEndpoint_app(t *testing.T) {
+=======
+func TestAccResourceEndpoint_appContainerNoPort(t *testing.T) {
+	appHandle := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAptibleEndpointAppContainerNoPort(appHandle),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aptible_app.test", "handle", appHandle),
+					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
+					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
+					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
+
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "env_id", strconv.Itoa(testEnvironmentId)),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "resource_type", "app"),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "endpoint_type", "https"),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "true"),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "platform", "alb"),
+					resource.TestCheckResourceAttrSet("aptible_endpoint.test", "endpoint_id"),
+					resource.TestMatchResourceAttr("aptible_endpoint.test", "virtual_domain", regexp.MustCompile(`app-.*\.on-aptible\.com`)),
+					resource.TestMatchResourceAttr("aptible_endpoint.test", "external_hostname", regexp.MustCompile(`elb.*\.aptible\.in`)),
+					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "dns_validation_record"),
+					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "dns_validation_value"),
+				),
+			},
+			{
+				ResourceName:      "aptible_endpoint.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceEndpoint_appContainerPort(t *testing.T) {
+>>>>>>> Stashed changes
 	appHandle := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -129,7 +170,11 @@ func TestAccResourceEndpoint_updateIPWhitelist(t *testing.T) {
 		CheckDestroy: testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
+<<<<<<< Updated upstream
 				Config: testAccAptibleEndpointApp(appHandle),
+=======
+				Config: testAccAptibleEndpointAppContainerNoPort(appHandle),
+>>>>>>> Stashed changes
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", appHandle),
 					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
@@ -292,6 +337,68 @@ resource "aptible_endpoint" "test" {
 	return output
 }
 
+<<<<<<< Updated upstream
+=======
+func testAccAptibleEndpointAppContainerNoPort(appHandle string) string {
+	output := fmt.Sprintf(`
+resource "aptible_app" "test" {
+	env_id = %d
+	handle = "%v"
+	config = {
+		"APTIBLE_DOCKER_IMAGE" = "nginx"
+	}
+	service {
+		process_type = "cmd"
+		container_memory_limit = 512
+		container_count = 1
+	}
+}
+
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	resource_id = aptible_app.test.app_id
+	resource_type = "app"
+	process_type = "cmd"
+	endpoint_type = "https"
+	default_domain = true
+	internal = true
+	platform = "alb"
+}`, testEnvironmentId, appHandle, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointAppContainerPorts(appHandle string) string {
+	output := fmt.Sprintf(`
+resource "aptible_app" "test" {
+	env_id = %d
+	handle = "%v"
+	config = {
+		"APTIBLE_DOCKER_IMAGE" = "caddy"
+	}
+	service {
+		process_type = "cmd"
+		container_memory_limit = 512
+		container_count = 1
+	}
+}
+
+resource "aptible_endpoint" "test" {
+	env_id = %d
+	resource_id = aptible_app.test.app_id
+	resource_type = "app"
+	process_type = "cmd"
+	container_ports = [80, 443]
+	endpoint_type = "tcp"
+	default_domain = true
+	internal = true
+	platform = "elb"
+}`, testEnvironmentId, appHandle, testEnvironmentId)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+>>>>>>> Stashed changes
 func testAccAptibleEndpointDatabase(dbHandle string) string {
 	output := fmt.Sprintf(`
 resource "aptible_database" "test" {

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -50,9 +50,6 @@ func TestAccResourceEndpoint_customDomain(t *testing.T) {
 	})
 }
 
-<<<<<<< Updated upstream
-func TestAccResourceEndpoint_app(t *testing.T) {
-=======
 func TestAccResourceEndpoint_appContainerNoPort(t *testing.T) {
 	appHandle := acctest.RandString(10)
 
@@ -91,7 +88,6 @@ func TestAccResourceEndpoint_appContainerNoPort(t *testing.T) {
 }
 
 func TestAccResourceEndpoint_appContainerPort(t *testing.T) {
->>>>>>> Stashed changes
 	appHandle := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -170,11 +166,7 @@ func TestAccResourceEndpoint_updateIPWhitelist(t *testing.T) {
 		CheckDestroy: testAccCheckEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-<<<<<<< Updated upstream
-				Config: testAccAptibleEndpointApp(appHandle),
-=======
 				Config: testAccAptibleEndpointAppContainerNoPort(appHandle),
->>>>>>> Stashed changes
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_app.test", "handle", appHandle),
 					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
@@ -337,8 +329,6 @@ resource "aptible_endpoint" "test" {
 	return output
 }
 
-<<<<<<< Updated upstream
-=======
 func testAccAptibleEndpointAppContainerNoPort(appHandle string) string {
 	output := fmt.Sprintf(`
 resource "aptible_app" "test" {
@@ -398,7 +388,6 @@ resource "aptible_endpoint" "test" {
 	return output
 }
 
->>>>>>> Stashed changes
 func testAccAptibleEndpointDatabase(dbHandle string) string {
 	output := fmt.Sprintf(`
 resource "aptible_database" "test" {


### PR DESCRIPTION
All tests passed but this one (local timeout):

![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/49049f81-31a4-4775-9613-fc9dad103bd0)

On run:

![image](https://github.com/aptible/terraform-provider-aptible/assets/2961973/15dd684f-330f-49e0-9b31-cbf478050f81)
