### PR TITLE
Fix demo example

### DIFF
--- a/examples/demo.tf
+++ b/examples/demo.tf
@@ -30,7 +30,7 @@ resource "aptible_app" "demo-app" {
   }
   service {
     process_type           = "background"
-    container_count        = 0
+    container_count        = 1
     container_memory_limit = 512
   }
 


### PR DESCRIPTION
The background task needs a container count of at least 1 to forward messages.