### PR TITLE
Parallelize acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,5 @@
 TEST?=./...
+TEST_PARALLEL?=12
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=aptible
 TEST_COUNT?=1
@@ -28,7 +29,7 @@ test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel $(TEST_PARALLEL) $(TESTARGS) -timeout 120m
 
 fmt:
 	gofmt -s -w .

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+
+	"github.com/aptible/go-deploy/aptible"
 	"github.com/aptible/go-deploy/client/operations"
 	"github.com/aptible/go-deploy/models"
 )
@@ -110,4 +113,24 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func WithTestEnvironment(t *testing.T, f func(env aptible.Environment)) {
+	client, err := aptible.SetUpClient()
+	if err != nil {
+		t.Fatalf("Failed to set up client for test environment - %s", err.Error())
+		return
+	}
+
+	env, err := client.CreateEnvironment(testOrganizationId, int64(testStackId), aptible.EnvironmentCreateAttrs{
+		Handle: acctest.RandString(10),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create test environment - %s", err.Error())
+		return
+	}
+
+	defer client.DeleteEnvironment(env.ID)
+
+	f(env)
 }

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -3,6 +3,7 @@ package aptible
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -115,7 +116,11 @@ func TestGenerateErrorFromClientError(t *testing.T) {
 	}
 }
 
-func WithTestEnvironment(t *testing.T, f func(env aptible.Environment)) {
+func WithTestAccEnvironment(t *testing.T, f func(env aptible.Environment)) {
+	if os.Getenv("TF_ACC") != "1" {
+		return
+	}
+
 	client, err := aptible.SetUpClient()
 	if err != nil {
 		t.Fatalf("Failed to set up client for test environment - %s", err.Error())

--- a/aptible/client_utils_test.go
+++ b/aptible/client_utils_test.go
@@ -130,7 +130,9 @@ func WithTestEnvironment(t *testing.T, f func(env aptible.Environment)) {
 		return
 	}
 
-	defer client.DeleteEnvironment(env.ID)
+	defer func() {
+		_ = client.DeleteEnvironment(env.ID)
+	}()
 
 	f(env)
 }

--- a/aptible/data_source_environment_test.go
+++ b/aptible/data_source_environment_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceEnvironment_validation(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps:             testSteps,
@@ -32,7 +32,7 @@ func TestAccDataSourceEnvironment_validation(t *testing.T) {
 func TestAccDataSourceEnvironment_basic(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Providers:         testAccProviders,

--- a/aptible/data_source_stack_test.go
+++ b/aptible/data_source_stack_test.go
@@ -24,7 +24,7 @@ func TestAccStackDataSource_validation(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		Steps:             testSteps,
@@ -52,7 +52,7 @@ func TestAccStackDataSource_basic(t *testing.T) {
 			return
 		}
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			PreCheck: func() {
 				testAccPreCheck(t)
 			},

--- a/aptible/provider_test.go
+++ b/aptible/provider_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var testEnvironmentId int
 var testOrganizationId string
 var testStackId int
 
@@ -18,7 +17,6 @@ var testAccProvider *schema.Provider
 var testAccProviderFactories map[string]func() (*schema.Provider, error)
 
 const (
-	AptibleEnvironmentId  = "APTIBLE_ENVIRONMENT_ID"
 	AptibleStackId        = "APTIBLE_STACK_ID"
 	AptibleOrganizationId = "APTIBLE_ORGANIZATION_ID"
 )
@@ -35,10 +33,6 @@ func init() {
 	}
 
 	// see testAccPreCheck for more details on this being set ahead of time for dx
-	envIdStr := os.Getenv(AptibleEnvironmentId)
-	envId, _ := strconv.Atoi(envIdStr)
-	testEnvironmentId = envId
-
 	testOrganizationId = os.Getenv(AptibleOrganizationId)
 
 	stackIdStr := os.Getenv(AptibleStackId)
@@ -56,14 +50,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 	if v := os.Getenv("APTIBLE_ACCESS_TOKEN"); v == "" {
 		t.Fatal("APTIBLE_ACCESS_TOKEN must be set for acceptance tests")
-	}
-
-	id := os.Getenv(AptibleEnvironmentId)
-	if id == "" {
-		t.Fatal(fmt.Sprintf("%s must be set for acceptance tests", AptibleEnvironmentId))
-	}
-	if _, err := strconv.Atoi(id); err != nil {
-		t.Fatal(fmt.Sprintf("%s is not a valid integer value", AptibleEnvironmentId))
 	}
 
 	if v := os.Getenv(AptibleOrganizationId); v == "" {

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -15,126 +15,134 @@ import (
 func TestAccResourceApp_basic(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleAppBasic(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
-				),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckAppDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleAppBasic(rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_app.test", "env_id"),
+						resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
+					),
+				},
+				{
+					ResourceName:      "aptible_app.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
-			{
-				ResourceName:      "aptible_app.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
+		})
 	})
 }
 
 func TestAccResourceApp_deploy(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleAppDeploy(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
-				),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckAppDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleAppDeploy(rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_app.test", "env_id"),
+						resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
+					),
+				},
+				{
+					ResourceName:      "aptible_app.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
-			{
-				ResourceName:      "aptible_app.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
+		})
 	})
 }
 
 func TestAccResourceApp_updateConfig(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleAppDeploy(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.OOPS", "mistake"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
-				),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckAppDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleAppDeploy(rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_app.test", "env_id"),
+						resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.OOPS", "mistake"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
+					),
+				},
+				{
+					ResourceName:      "aptible_app.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccAptibleAppUpdateConfig(rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "httpd:alpine"),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "nothing"),
+						resource.TestCheckNoResourceAttr("aptible_app.test", "config.OOPS"),
+					),
+				},
 			},
-			{
-				ResourceName:      "aptible_app.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAptibleAppUpdateConfig(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "httpd:alpine"),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "nothing"),
-					resource.TestCheckNoResourceAttr("aptible_app.test", "config.OOPS"),
-				),
-			},
-		},
+		})
 	})
 }
 
 func TestAccResourceApp_scaleDown(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAppDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleAppDeploy(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_app.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
-					resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
-					resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
-					resource.TestCheckResourceAttr("aptible_app.test", "service.0.container_count", "1"),
-				),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckAppDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleAppDeploy(rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_app.test", "env_id"),
+						resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.APTIBLE_DOCKER_IMAGE", "nginx"),
+						resource.TestCheckResourceAttr("aptible_app.test", "config.WHATEVER", "something"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "app_id"),
+						resource.TestCheckResourceAttrSet("aptible_app.test", "git_repo"),
+						resource.TestCheckResourceAttr("aptible_app.test", "service.0.container_count", "1"),
+					),
+				},
+				{
+					ResourceName:      "aptible_app.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccAptibleAppScaleDown(rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_app.test", "service.0.container_count", "0"),
+					),
+				},
 			},
-			{
-				ResourceName:      "aptible_app.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAptibleAppScaleDown(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_app.test", "service.0.container_count", "0"),
-				),
-			},
-		},
+		})
 	})
 }
 
@@ -165,17 +173,29 @@ func testAccCheckAppDestroy(s *terraform.State) error {
 
 func testAccAptibleAppBasic(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_app" "test" {
-    env_id = %d
-    handle = "%v"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_app" "test" {
+			env_id = aptible_environment.test.env_id
+			handle = "%v"
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleAppDeploy(handle string) string {
 	return fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
 	resource "aptible_app" "test" {
-		env_id = %d
+		env_id = aptible_environment.test.env_id
 		handle = "%v"
 		config = {
 			"APTIBLE_DOCKER_IMAGE" = "nginx"
@@ -189,13 +209,19 @@ func testAccAptibleAppDeploy(handle string) string {
 			container_count = 1
 		}
 	}
-	`, testEnvironmentId, handle)
+	`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleAppUpdateConfig(handle string) string {
 	return fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
 	resource "aptible_app" "test" {
-		env_id = %d
+		env_id = aptible_environment.test.env_id
 		handle = "%v"
 		config = {
 			"APTIBLE_DOCKER_IMAGE" = "httpd:alpine"
@@ -207,13 +233,19 @@ func testAccAptibleAppUpdateConfig(handle string) string {
 			container_count = 1
 		}
 	}
-	`, testEnvironmentId, handle)
+	`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleAppScaleDown(handle string) string {
 	return fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
 	resource "aptible_app" "test" {
-		env_id = %d
+		env_id = aptible_environment.test.env_id
 		handle = "%v"
 		config = {
 			"APTIBLE_DOCKER_IMAGE" = "nginx"
@@ -226,5 +258,5 @@ func testAccAptibleAppScaleDown(handle string) string {
 			container_count = 0
 		}
 	}
-	`, testEnvironmentId, handle)
+	`, handle, testOrganizationId, testStackId, handle)
 }

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccResourceApp_basic(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppDestroy,
@@ -41,7 +41,7 @@ func TestAccResourceApp_basic(t *testing.T) {
 func TestAccResourceApp_deploy(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppDestroy,
@@ -69,7 +69,7 @@ func TestAccResourceApp_deploy(t *testing.T) {
 func TestAccResourceApp_updateConfig(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppDestroy,
@@ -106,7 +106,7 @@ func TestAccResourceApp_updateConfig(t *testing.T) {
 func TestAccResourceApp_scaleDown(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAppDestroy,

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccResourceApp_basic(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -43,7 +43,7 @@ func TestAccResourceApp_basic(t *testing.T) {
 func TestAccResourceApp_deploy(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -73,7 +73,7 @@ func TestAccResourceApp_deploy(t *testing.T) {
 func TestAccResourceApp_updateConfig(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -112,7 +112,7 @@ func TestAccResourceApp_updateConfig(t *testing.T) {
 func TestAccResourceApp_scaleDown(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -20,7 +20,7 @@ func TestAccResourceDatabase_basic(t *testing.T) {
 	// Can't use an aptible_environment TF resource with databases because, when
 	// the destroy is attempted, the environment will not permit deletion due to
 	// the database's final backup
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -53,7 +53,7 @@ func TestAccResourceDatabase_basic(t *testing.T) {
 func TestAccResourceDatabase_redis(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -88,7 +88,7 @@ func TestAccResourceDatabase_redis(t *testing.T) {
 func TestAccResourceDatabase_version(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -121,7 +121,7 @@ func TestAccResourceDatabase_version(t *testing.T) {
 func TestAccResourceDatabase_update(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -160,7 +160,7 @@ func TestAccResourceDatabase_update(t *testing.T) {
 func TestAccResourceDatabase_expectError(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccResourceDatabase_basic(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDatabaseDestroy,
@@ -48,7 +48,7 @@ func TestAccResourceDatabase_basic(t *testing.T) {
 func TestAccResourceDatabase_redis(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDatabaseDestroy,
@@ -81,7 +81,7 @@ func TestAccResourceDatabase_redis(t *testing.T) {
 func TestAccResourceDatabase_version(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDatabaseDestroy,
@@ -112,7 +112,7 @@ func TestAccResourceDatabase_version(t *testing.T) {
 func TestAccResourceDatabase_update(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDatabaseDestroy,
@@ -149,7 +149,7 @@ func TestAccResourceDatabase_update(t *testing.T) {
 func TestAccResourceDatabase_expectError(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDatabaseDestroy,

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccResourceEndpoint_customDomain(t *testing.T) {
 	appHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,
@@ -53,7 +53,7 @@ func TestAccResourceEndpoint_customDomain(t *testing.T) {
 func TestAccResourceEndpoint_appContainerNoPort(t *testing.T) {
 	appHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,
@@ -90,7 +90,7 @@ func TestAccResourceEndpoint_appContainerNoPort(t *testing.T) {
 func TestAccResourceEndpoint_appContainerPort(t *testing.T) {
 	appHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,
@@ -128,7 +128,7 @@ func TestAccResourceEndpoint_appContainerPort(t *testing.T) {
 func TestAccResourceEndpoint_appContainerPorts(t *testing.T) {
 	appHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,
@@ -167,7 +167,7 @@ func TestAccResourceEndpoint_appContainerPorts(t *testing.T) {
 func TestAccResourceEndpoint_db(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,
@@ -200,7 +200,7 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 func TestAccResourceEndpoint_updateIPWhitelist(t *testing.T) {
 	appHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,
@@ -237,7 +237,7 @@ func TestAccResourceEndpoint_updateIPWhitelist(t *testing.T) {
 }
 
 func TestAccResourceEndpoint_expectError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEndpointDestroy,

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -168,7 +168,7 @@ func TestAccResourceEndpoint_appContainerPorts(t *testing.T) {
 func TestAccResourceEndpoint_db(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -547,18 +547,18 @@ func testAccAptibleEndpointUpdateIPWhitelist(appHandle string) string {
 }
 
 func testAccAptibleEndpointInvalidResourceType() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		resource_id = 1
 		resource_type = "should-error"
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidEndpointType() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		resource_id = 1
@@ -566,13 +566,13 @@ func testAccAptibleEndpointInvalidEndpointType() string {
 		process_type = "cmd"
 		default_domain = true
 		endpoint_type = "should-error"
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidPlatform() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		resource_id = 1
@@ -580,13 +580,13 @@ func testAccAptibleEndpointInvalidPlatform() string {
 		process_type = "cmd"
 		default_domain = true
 		platform = "should-error"
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidDomain() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		resource_id = 1
@@ -596,13 +596,13 @@ func testAccAptibleEndpointInvalidDomain() string {
 		platform = "alb"
 		managed = true
 		domain = ""
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidContainerPort() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		resource_id = 1
@@ -612,13 +612,13 @@ func testAccAptibleEndpointInvalidContainerPort() string {
 		platform = "alb"
 		managed = true
 		container_port = 99999
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidContainerPortOnTcp() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		endpoint_type = "tcp"
@@ -629,13 +629,13 @@ func testAccAptibleEndpointInvalidContainerPortOnTcp() string {
 		platform = "alb"
 		managed = true
 		container_port = 3000
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidContainerPortOnTls() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		endpoint_type = "tls"
@@ -646,7 +646,7 @@ func testAccAptibleEndpointInvalidContainerPortOnTls() string {
 		platform = "alb"
 		managed = true
 		container_port = 3000
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
@@ -668,7 +668,7 @@ func testAccAptibleEndpointInvalidContainerPorts() string {
 }
 
 func testAccAptibleEndpointInvalidContainerPortsOnHttp() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		endpoint_type = "https"
@@ -679,13 +679,13 @@ func testAccAptibleEndpointInvalidContainerPortsOnHttp() string {
 		platform = "alb"
 		managed = true
 		container_ports = [3000]
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }
 
 func testAccAptibleEndpointInvalidMultipleContainerPortFields() string {
-	output := fmt.Sprint(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		endpoint_type = "tcp"
@@ -697,7 +697,7 @@ func testAccAptibleEndpointInvalidMultipleContainerPortFields() string {
 		managed = true
 		container_port = 3000
 		container_ports = [3000]
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -652,7 +652,7 @@ func testAccAptibleEndpointInvalidContainerPortOnTls() string {
 }
 
 func testAccAptibleEndpointInvalidContainerPorts() string {
-	output := fmt.Sprintf(`
+	output := `
 	resource "aptible_endpoint" "test" {
 		env_id = -1
 		resource_id = 1
@@ -662,7 +662,7 @@ func testAccAptibleEndpointInvalidContainerPorts() string {
 		platform = "alb"
 		managed = true
 		container_ports = [99999]
-	}`)
+	}`
 	log.Println("HCL generated: ", output)
 	return output
 }

--- a/aptible/resource_environment_test.go
+++ b/aptible/resource_environment_test.go
@@ -154,17 +154,19 @@ func TestAccResourceEnvironment_update(t *testing.T) {
 
 func testAccAptibleEnvironment(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_environment" "test" {
-	handle = "%s"
-	org_id = "%s"
-	stack_id = "%v"
-}`, handle, testOrganizationId, testStackId)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+	`, handle, testOrganizationId, testStackId)
 }
 
 func testAccAptibleEnvironmentWithoutOrg(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_environment" "test" {
-	handle = "%s"
-	stack_id = "%v"
-}`, handle, testStackId)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		stack_id = "%v"
+	}
+	`, handle, testStackId)
 }

--- a/aptible/resource_environment_test.go
+++ b/aptible/resource_environment_test.go
@@ -38,7 +38,7 @@ func TestAccResourceEnvironment_validation(t *testing.T) {
 		ExpectError: regexp.MustCompile(fmt.Sprintf(`expected %q to be a valid UUID, got invalid-uuid`, "org_id")),
 	})
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
@@ -74,7 +74,7 @@ func testAccCheckEnvironmentDestroy(s *terraform.State) error {
 func TestAccResourceEnvironment_basic(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
@@ -99,7 +99,7 @@ func TestAccResourceEnvironment_basic(t *testing.T) {
 func TestAccResourceEnvironment_basic_no_org(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckEnvironmentDestroy,
@@ -124,7 +124,7 @@ func TestAccResourceEnvironment_update(t *testing.T) {
 	rHandle := acctest.RandString(10)
 	rUpdatedHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckEnvironmentDestroy,

--- a/aptible/resource_log_drain_test.go
+++ b/aptible/resource_log_drain_test.go
@@ -15,29 +15,32 @@ import (
 func TestAccResourceLogDrain_elasticsearch(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLogDrainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleLogDrainElastic(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "elasticsearch_database"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "logging_token", "test_token"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "pipeline", "test_token"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_apps", "true"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_databases", "true"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_databases", "true"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_proxies", "false"),
-				),
-			}, {
-				ResourceName:      "aptible_log_drain.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckLogDrainDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleLogDrainElastic(env.ID, rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "elasticsearch_database"),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "env_id", strconv.Itoa(int(env.ID))),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "logging_token", "test_token"),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "pipeline", "test_token"),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_apps", "true"),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_databases", "true"),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_databases", "true"),
+						resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_proxies", "false"),
+					),
+				}, {
+					ResourceName:      "aptible_log_drain.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
-		},
+		})
 	})
 }
 
@@ -53,6 +56,7 @@ func TestAccResourceLogDrain_syslog(t *testing.T) {
 				Config: testAccAptibleLogDrainSyslog(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "syslog_tls_tcp"),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_log_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_host", "syslog.aptible.com"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_port", "1234"),
@@ -82,8 +86,9 @@ func TestAccResourceLogDrain_https(t *testing.T) {
 				Config: testAccAptibleLogDrainHttps(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "https_post"),
-					resource.TestCheckResourceAttr("aptible_log_drain.test", "url", "https://test.aptible.com"),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_log_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
+					resource.TestCheckResourceAttr("aptible_log_drain.test", "url", "https://test.aptible.com"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_apps", "false"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_databases", "false"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_ephemeral_sessions", "false"),
@@ -110,6 +115,7 @@ func TestAccResourceLogDrain_datadog(t *testing.T) {
 				Config: testAccAptibleLogDrainDatadog(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "datadog"),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_log_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_username", "test_username"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "logging_token", "test_token"),
@@ -141,6 +147,7 @@ func TestAccResourceLogDrain_sumologic(t *testing.T) {
 				Config: testAccAptibleLogDrainSumologic(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "sumologic"),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_log_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "url", "https://www.sumologic.com"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_apps", "true"),
@@ -169,6 +176,7 @@ func TestAccResourceLogDrain_logdna(t *testing.T) {
 				Config: testAccAptibleLogDrainLogdna(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "logdna"),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_log_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_username", "test_username"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "token", "test_username"),
@@ -198,6 +206,7 @@ func TestAccResourceLogDrain_papertrail(t *testing.T) {
 				Config: testAccAptibleLogDrainPapertrail(rHandle),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_type", "papertrail"),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_log_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_host", "www.papertrail.com"),
 					resource.TestCheckResourceAttr("aptible_log_drain.test", "drain_port", "1234"),
@@ -240,95 +249,133 @@ func testAccCheckLogDrainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAptibleLogDrainElastic(handle string) string {
+func testAccAptibleLogDrainElastic(envID int64, handle string) string {
+	// Cannot use aptible_environment TF resource with a database since the final
+	// DB backup will prevent the environment from being deleted
 	return fmt.Sprintf(`
-resource "aptible_database" "test" {
-	env_id = %d
-	handle = "%v"
-	database_type = "postgresql"
-	container_size = 1024
-	disk_size = 10
-}
+	resource "aptible_database" "test" {
+		env_id = %d
+		handle = "%v"
+		database_type = "postgresql"
+		container_size = 1024
+		disk_size = 10
+	}
 
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    database_id = aptible_database.test.database_id
-    handle = "%v"
-    drain_type = "elasticsearch_database"
-    pipeline = "test_token"
-}
-`, testEnvironmentId, handle, testEnvironmentId, handle)
+	resource "aptible_log_drain" "test" {
+		env_id = %d
+		database_id = aptible_database.test.database_id
+		handle = "%v"
+		drain_type = "elasticsearch_database"
+		pipeline = "test_token"
+	}
+`, envID, handle, envID, handle)
 }
 
 func testAccAptibleLogDrainSyslog(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "syslog_tls_tcp"
-    drain_host = "syslog.aptible.com"
-    drain_port = "1234"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_log_drain" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		drain_type = "syslog_tls_tcp"
+		drain_host = "syslog.aptible.com"
+		drain_port = "1234"
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleLogDrainHttps(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    url = "https://test.aptible.com"
-    drain_apps = false
-    drain_databases = false
-    drain_ephemeral_sessions = false
-    drain_proxies = true
-    drain_type = "https_post"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_log_drain" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		url = "https://test.aptible.com"
+		drain_apps = false
+		drain_databases = false
+		drain_ephemeral_sessions = false
+		drain_proxies = true
+		drain_type = "https_post"
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleLogDrainDatadog(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "datadog"
-    token = "test_username"
-    tags = "test_token"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_log_drain" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		drain_type = "datadog"
+		token = "test_username"
+		tags = "test_token"
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleLogDrainSumologic(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "sumologic"
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_log_drain" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		drain_type = "sumologic"
 		url = "https://www.sumologic.com"
-}
-`, testEnvironmentId, handle)
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleLogDrainLogdna(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "logdna"
-    token = "test_username"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_log_drain" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		drain_type = "logdna"
+		token = "test_username"
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleLogDrainPapertrail(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_log_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "papertrail"
-    drain_host = "www.papertrail.com"
-    drain_port = "1234"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_log_drain" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		drain_type = "papertrail"
+		drain_host = "www.papertrail.com"
+		drain_port = "1234"
+	}
+`, handle, testOrganizationId, testStackId, handle)
 }

--- a/aptible/resource_log_drain_test.go
+++ b/aptible/resource_log_drain_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccResourceLogDrain_elasticsearch(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,
@@ -44,7 +44,7 @@ func TestAccResourceLogDrain_elasticsearch(t *testing.T) {
 func TestAccResourceLogDrain_syslog(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,
@@ -73,7 +73,7 @@ func TestAccResourceLogDrain_syslog(t *testing.T) {
 func TestAccResourceLogDrain_https(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,
@@ -101,7 +101,7 @@ func TestAccResourceLogDrain_https(t *testing.T) {
 func TestAccResourceLogDrain_datadog(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,
@@ -132,7 +132,7 @@ func TestAccResourceLogDrain_datadog(t *testing.T) {
 func TestAccResourceLogDrain_sumologic(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,
@@ -160,7 +160,7 @@ func TestAccResourceLogDrain_sumologic(t *testing.T) {
 func TestAccResourceLogDrain_logdna(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,
@@ -189,7 +189,7 @@ func TestAccResourceLogDrain_logdna(t *testing.T) {
 func TestAccResourceLogDrain_papertrail(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLogDrainDestroy,

--- a/aptible/resource_log_drain_test.go
+++ b/aptible/resource_log_drain_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccResourceLogDrain_elasticsearch(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,

--- a/aptible/resource_metric_drain_test.go
+++ b/aptible/resource_metric_drain_test.go
@@ -108,7 +108,7 @@ func TestAccResourceMetricDrain_influxdb_database_validation(t *testing.T) {
 func TestAccResourceMetricDrain_influxdb_database(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:          func() { testAccPreCheck(t) },
 			ProviderFactories: testAccProviderFactories,

--- a/aptible/resource_metric_drain_test.go
+++ b/aptible/resource_metric_drain_test.go
@@ -54,7 +54,7 @@ func TestAccResourceMetricDrain_validation(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,
@@ -97,7 +97,7 @@ func TestAccResourceMetricDrain_influxdb_database_validation(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,
@@ -108,7 +108,7 @@ func TestAccResourceMetricDrain_influxdb_database_validation(t *testing.T) {
 func TestAccResourceMetricDrain_influxdb_database(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,
@@ -160,7 +160,7 @@ func TestAccResourceMetricDrain_influxdb_validation(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,
@@ -171,7 +171,7 @@ func TestAccResourceMetricDrain_influxdb_validation(t *testing.T) {
 func TestAccResourceMetricDrain_influxdb(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,
@@ -226,7 +226,7 @@ func TestAccResourceMetricDrain_datadog_validation(t *testing.T) {
 		})
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,
@@ -237,7 +237,7 @@ func TestAccResourceMetricDrain_datadog_validation(t *testing.T) {
 func TestAccResourceMetricDrain_datadog(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccCheckMetricDrainDestroy,

--- a/aptible/resource_metric_drain_test.go
+++ b/aptible/resource_metric_drain_test.go
@@ -108,25 +108,27 @@ func TestAccResourceMetricDrain_influxdb_database_validation(t *testing.T) {
 func TestAccResourceMetricDrain_influxdb_database(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		CheckDestroy:      testAccCheckMetricDrainDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleMetricDrainInfluxDBDatabase(rHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_metric_drain.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_metric_drain.test", "handle", rHandle),
-					resource.TestCheckResourceAttr("aptible_metric_drain.test", "drain_type", "influxdb_database"),
-				),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:          func() { testAccPreCheck(t) },
+			ProviderFactories: testAccProviderFactories,
+			CheckDestroy:      testAccCheckMetricDrainDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleMetricDrainInfluxDBDatabase(env.ID, rHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_metric_drain.test", "env_id", strconv.Itoa(int(env.ID))),
+						resource.TestCheckResourceAttr("aptible_metric_drain.test", "handle", rHandle),
+						resource.TestCheckResourceAttr("aptible_metric_drain.test", "drain_type", "influxdb_database"),
+					),
+				},
+				{
+					ResourceName:      "aptible_metric_drain.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
-			{
-				ResourceName:      "aptible_metric_drain.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
+		})
 	})
 }
 
@@ -179,7 +181,7 @@ func TestAccResourceMetricDrain_influxdb(t *testing.T) {
 			{
 				Config: testAccAptibleMetricDrainInfluxDB(rHandle),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_metric_drain.test", "env_id", strconv.Itoa(testEnvironmentId)),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_metric_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_metric_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_metric_drain.test", "drain_type", "influxdb"),
 					resource.TestCheckResourceAttr("aptible_metric_drain.test", "url", "https://test.aptible.com:2022"),
@@ -245,7 +247,7 @@ func TestAccResourceMetricDrain_datadog(t *testing.T) {
 			{
 				Config: testAccAptibleMetricDrainDatadog(rHandle),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_metric_drain.test", "env_id", strconv.Itoa(testEnvironmentId)),
+					resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_metric_drain.test", "env_id"),
 					resource.TestCheckResourceAttr("aptible_metric_drain.test", "handle", rHandle),
 					resource.TestCheckResourceAttr("aptible_metric_drain.test", "drain_type", "datadog"),
 					resource.TestCheckResourceAttr("aptible_metric_drain.test", "api_key", "test_api_key"),
@@ -284,47 +286,59 @@ func testAccCheckMetricDrainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAptibleMetricDrainInfluxDBDatabase(handle string) string {
+func testAccAptibleMetricDrainInfluxDBDatabase(envId int64, handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_database" "test" {
-	env_id = %d
-	handle = "%v"
-	database_type = "influxdb"
-	container_size = 1024
-	disk_size = 10
-}
+	resource "aptible_database" "test" {
+		env_id = %d
+		handle = "%v"
+		database_type = "influxdb"
+		container_size = 1024
+		disk_size = 10
+	}
 
-resource "aptible_metric_drain" "test" {
-    env_id = %d
-    database_id = aptible_database.test.database_id
-    handle = "%v"
-    drain_type = "influxdb_database"
-}
-`, testEnvironmentId, handle, testEnvironmentId, handle)
+	resource "aptible_metric_drain" "test" {
+			env_id = %d
+			database_id = aptible_database.test.database_id
+			handle = "%v"
+			drain_type = "influxdb_database"
+	}
+	`, envId, handle, envId, handle)
 }
 
 func testAccAptibleMetricDrainInfluxDB(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_metric_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "influxdb"
-		url = "https://test.aptible.com:2022"
-		username = "test_user"
-		password = "test_password"
-		database = "test_db"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_metric_drain" "test" {
+			env_id = aptible_environment.test.env_id
+			handle = "%v"
+			drain_type = "influxdb"
+			url = "https://test.aptible.com:2022"
+			username = "test_user"
+			password = "test_password"
+			database = "test_db"
+	}
+	`, handle, testOrganizationId, testStackId, handle)
 }
 
 func testAccAptibleMetricDrainDatadog(handle string) string {
 	return fmt.Sprintf(`
-resource "aptible_metric_drain" "test" {
-    env_id = %d
-    handle = "%v"
-    drain_type = "datadog"
-    api_key = "test_api_key"
-		series_url = "https://test.aptible.com:2022"
-}
-`, testEnvironmentId, handle)
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_metric_drain" "test" {
+			env_id = aptible_environment.test.env_id
+			handle = "%v"
+			drain_type = "datadog"
+			api_key = "test_api_key"
+			series_url = "https://test.aptible.com:2022"
+	}
+	`, handle, testOrganizationId, testStackId, handle)
 }

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -18,7 +18,7 @@ func TestAccResourceReplica_basic(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 	replicaHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -57,7 +57,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 	replicaHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,
@@ -102,7 +102,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 func TestAccResourceReplica_expectError(t *testing.T) {
 	replicaHandle := acctest.RandString(10)
 
-	WithTestEnvironment(t, func(env aptible.Environment) {
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
 		resource.ParallelTest(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },
 			Providers:    testAccProviders,

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -18,7 +18,7 @@ func TestAccResourceReplica_basic(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 	replicaHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckReplicaDestroy,
@@ -55,7 +55,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 	replicaHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckReplicaDestroy,
@@ -98,7 +98,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 func TestAccResourceReplica_expectError(t *testing.T) {
 	replicaHandle := acctest.RandString(10)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckReplicaDestroy,

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -18,36 +18,38 @@ func TestAccResourceReplica_basic(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 	replicaHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckReplicaDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleReplicaBasic(dbHandle, replicaHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_database.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
-					resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
-					resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
-					resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
-					resource.TestCheckResourceAttrSet("aptible_database.test", "default_connection_url"),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckReplicaDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleReplicaBasic(env.ID, dbHandle, replicaHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_database.test", "handle", dbHandle),
+						resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(int(env.ID))),
+						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
+						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
+						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
+						resource.TestCheckResourceAttrSet("aptible_database.test", "default_connection_url"),
 
-					resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
-					resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
-					resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
-					resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
-					resource.TestCheckResourceAttrSet("aptible_replica.test", "default_connection_url"),
-				),
+						resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
+						resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(int(env.ID))),
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
+						resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
+						resource.TestCheckResourceAttrSet("aptible_replica.test", "default_connection_url"),
+					),
+				},
+				{
+					ResourceName:      "aptible_database.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
-			{
-				ResourceName:      "aptible_database.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
+		})
 	})
 }
 
@@ -55,63 +57,67 @@ func TestAccResourceReplica_update(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 	replicaHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckReplicaDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAptibleReplicaBasic(dbHandle, replicaHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_database.test", "handle", dbHandle),
-					resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
-					resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
-					resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
-					resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
-					resource.TestCheckResourceAttrSet("aptible_database.test", "default_connection_url"),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckReplicaDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccAptibleReplicaBasic(env.ID, dbHandle, replicaHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_database.test", "handle", dbHandle),
+						resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(int(env.ID))),
+						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
+						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
+						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
+						resource.TestCheckResourceAttrSet("aptible_database.test", "default_connection_url"),
 
-					resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
-					resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(testEnvironmentId)),
-					resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
-					resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
-					resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
-					resource.TestCheckResourceAttrSet("aptible_replica.test", "default_connection_url"),
-				),
+						resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
+						resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(int(env.ID))),
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
+						resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
+						resource.TestCheckResourceAttrSet("aptible_replica.test", "default_connection_url"),
+					),
+				},
+				{
+					ResourceName:      "aptible_database.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccAptibleReplicaUpdate(env.ID, dbHandle, replicaHandle),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "512"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "20"),
+					),
+				},
 			},
-			{
-				ResourceName:      "aptible_database.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAptibleReplicaUpdate(dbHandle, replicaHandle),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "512"),
-					resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "20"),
-				),
-			},
-		},
+		})
 	})
 }
 
 func TestAccResourceReplica_expectError(t *testing.T) {
 	replicaHandle := acctest.RandString(10)
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckReplicaDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccAptibleReplicaInvalidContainerSize(replicaHandle),
-				ExpectError: regexp.MustCompile(`expected container_size to be one of .*, got 0`),
+	WithTestEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckReplicaDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccAptibleReplicaInvalidContainerSize(env.ID, replicaHandle),
+					ExpectError: regexp.MustCompile(`expected container_size to be one of .*, got 0`),
+				},
+				{
+					Config:      testAccAptibleReplicaInvalidDiskSize(env.ID, replicaHandle),
+					ExpectError: regexp.MustCompile(`expected disk_size to be in the range .*, got 0`),
+				},
 			},
-			{
-				Config:      testAccAptibleReplicaInvalidDiskSize(replicaHandle),
-				ExpectError: regexp.MustCompile(`expected disk_size to be in the range .*, got 0`),
-			},
-		},
+		})
 	})
 }
 
@@ -159,22 +165,22 @@ func testAccCheckReplicaDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAptibleReplicaBasic(dbHandle string, replicaHandle string) string {
+func testAccAptibleReplicaBasic(envId int64, dbHandle string, replicaHandle string) string {
 	return fmt.Sprintf(`
-resource "aptible_database" "test" {
-    env_id = %d
-	handle = "%v"
+	resource "aptible_database" "test" {
+			env_id = %d
+		handle = "%v"
+	}
+
+	resource "aptible_replica" "test" {
+		env_id = %d
+		handle = "%v"
+		primary_database_id = aptible_database.test.database_id
+	}
+	`, envId, dbHandle, envId, replicaHandle)
 }
 
-resource "aptible_replica" "test" {
-	env_id = %d
-	handle = "%v"
-	primary_database_id = aptible_database.test.database_id
-}
-`, testEnvironmentId, dbHandle, testEnvironmentId, replicaHandle)
-}
-
-func testAccAptibleReplicaUpdate(dbHandle string, repHandle string) string {
+func testAccAptibleReplicaUpdate(envId int64, dbHandle string, repHandle string) string {
 	return fmt.Sprintf(`
 	resource "aptible_database" "test" {
 		env_id = %d
@@ -188,27 +194,27 @@ func testAccAptibleReplicaUpdate(dbHandle string, repHandle string) string {
 		container_size = %d
 		disk_size = %d
 	}
-`, testEnvironmentId, dbHandle, testEnvironmentId, repHandle, 512, 20)
+	`, envId, dbHandle, envId, repHandle, 512, 20)
 }
 
-func testAccAptibleReplicaInvalidContainerSize(replicaHandle string) string {
+func testAccAptibleReplicaInvalidContainerSize(envId int64, replicaHandle string) string {
 	return fmt.Sprintf(`
-resource "aptible_replica" "test" {
-	env_id = %d
-	handle = "%v"
-	primary_database_id = "1"
-	container_size = %d
-}
-`, testEnvironmentId, replicaHandle, 0)
+	resource "aptible_replica" "test" {
+		env_id = %d
+		handle = "%v"
+		primary_database_id = "1"
+		container_size = %d
+	}
+	`, envId, replicaHandle, 0)
 }
 
-func testAccAptibleReplicaInvalidDiskSize(replicaHandle string) string {
+func testAccAptibleReplicaInvalidDiskSize(envId int64, replicaHandle string) string {
 	return fmt.Sprintf(`
-resource "aptible_replica" "test" {
-	env_id = %d
-	handle = "%v"
-	primary_database_id = "1"
-	disk_size = %d
-}
-`, testEnvironmentId, replicaHandle, 0)
+	resource "aptible_replica" "test" {
+		env_id = %d
+		handle = "%v"
+		primary_database_id = "1"
+		disk_size = %d
+	}
+	`, envId, replicaHandle, 0)
 }


### PR DESCRIPTION
This PR drastically speeds up acceptance tests by executing them in parallel and eliminating the use of a single, externally-created test environment. Now, each test provisions an environment for the duration of the test.

```
❯ make testacc
...
PASS
ok      github.com/aptible/terraform-provider-aptible/aptible   490.414s
```