### PR TITLE
Make acceptance test timeout configurable

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 TEST?=./...
 TEST_PARALLEL?=12
+TEST_TIMEOUT?=30m
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PKG_NAME=aptible
 TEST_COUNT?=1
@@ -29,7 +30,7 @@ test: fmtcheck
 	go test $(TEST) $(TESTARGS) -timeout=120s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel $(TEST_PARALLEL) $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test $(TEST) -v -count $(TEST_COUNT) -parallel $(TEST_PARALLEL) -timeout $(TEST_TIMEOUT) $(TESTARGS)
 
 fmt:
 	gofmt -s -w .


### PR DESCRIPTION
Reduces the acceptance test timeout to 30 minutes since, with parallelization, it usually completes in under 10 minutes. The timeout can also be configured in case parallelization is decreased and the tests need more time to complete.