### PR TITLE
Migrate to a more easily extensible provider metadata struct

### DIFF
--- a/aptible/data_source_environment.go
+++ b/aptible/data_source_environment.go
@@ -1,7 +1,6 @@
 package aptible
 
 import (
-	"github.com/aptible/go-deploy/aptible"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -22,7 +21,7 @@ func dataSourceEnvironment() *schema.Resource {
 }
 
 func dataSourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("handle").(string)
 	id, err := client.GetEnvironmentIDFromHandle(handle)
 	if err != nil {

--- a/aptible/data_source_environment.go
+++ b/aptible/data_source_environment.go
@@ -21,7 +21,7 @@ func dataSourceEnvironment() *schema.Resource {
 }
 
 func dataSourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 	id, err := client.GetEnvironmentIDFromHandle(handle)
 	if err != nil {

--- a/aptible/data_source_stack.go
+++ b/aptible/data_source_stack.go
@@ -25,7 +25,7 @@ func dataSourceStack() *schema.Resource {
 }
 
 func dataSourceStackRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("name").(string)
 	stack, err := client.GetStackByName(handle)
 	if err != nil {

--- a/aptible/data_source_stack.go
+++ b/aptible/data_source_stack.go
@@ -1,7 +1,6 @@
 package aptible
 
 import (
-	"github.com/aptible/go-deploy/aptible"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -26,7 +25,7 @@ func dataSourceStack() *schema.Resource {
 }
 
 func dataSourceStackRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("name").(string)
 	stack, err := client.GetStackByName(handle)
 	if err != nil {

--- a/aptible/provider.go
+++ b/aptible/provider.go
@@ -55,21 +55,21 @@ func providerConfigureWithContext(context.Context, *schema.ResourceData) (interf
 		return nil, diags
 	}
 
-	return &providerMeta{
+	return &providerMetadata{
 		LegacyClient: client,
 		Client:       aptibleapi.NewAPIClient(aptibleapi.NewAPIConfiguration()),
 		Token:        token,
 	}, nil
 }
 
-type providerMeta struct {
+type providerMetadata struct {
 	LegacyClient *aptible.Client
 	Client       *aptibleapi.APIClient
 	Token        string
 }
 
 // Configures the provided context to work with aptibleapi.APIClient requests
-func (m *providerMeta) APIContext(ctx context.Context) context.Context {
+func (m *providerMetadata) APIContext(ctx context.Context) context.Context {
 	// Override the default API url with APTIBLE_API_ROOT_URL, if non-empty
 	if url := os.Getenv("APTIBLE_API_ROOT_URL"); url != "" {
 		ctx = context.WithValue(ctx, aptibleapi.ContextServerVariables, map[string]string{"url": url})

--- a/aptible/provider.go
+++ b/aptible/provider.go
@@ -28,6 +28,10 @@ func Provider() *schema.Provider {
 	}
 }
 
+type providerMeta struct {
+	LegacyClient *aptible.Client
+}
+
 func providerConfigureWithContext(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -41,5 +45,7 @@ func providerConfigureWithContext(context.Context, *schema.ResourceData) (interf
 		log.Println("[ERR] Error in attempting to start the provider", err)
 		return nil, diags
 	}
-	return client, nil
+	return &providerMeta{
+		LegacyClient: client,
+	}, nil
 }

--- a/aptible/provider.go
+++ b/aptible/provider.go
@@ -3,7 +3,9 @@ package aptible
 import (
 	"context"
 	"log"
+	"os"
 
+	"github.com/aptible/aptible-api-go/aptibleapi"
 	"github.com/aptible/go-deploy/aptible"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -28,10 +30,6 @@ func Provider() *schema.Provider {
 	}
 }
 
-type providerMeta struct {
-	LegacyClient *aptible.Client
-}
-
 func providerConfigureWithContext(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -45,7 +43,47 @@ func providerConfigureWithContext(context.Context, *schema.ResourceData) (interf
 		log.Println("[ERR] Error in attempting to start the provider", err)
 		return nil, diags
 	}
+
+	token, err := aptible.GetToken()
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "There was an error when initializing the provider.",
+			Detail:   "There was an error when initializing the provider.",
+		})
+		log.Println("[ERR] Error in attempting to start the provider", err)
+		return nil, diags
+	}
+
 	return &providerMeta{
 		LegacyClient: client,
+		Client:       aptibleapi.NewAPIClient(aptibleapi.NewAPIConfiguration()),
+		Token:        token,
 	}, nil
+}
+
+type providerMeta struct {
+	LegacyClient *aptible.Client
+	Client       *aptibleapi.APIClient
+	Token        string
+}
+
+// Configures the provided context to work with aptibleapi.APIClient requests
+func (m *providerMeta) APIContext(ctx context.Context) context.Context {
+	// Override the default API url with APTIBLE_API_ROOT_URL, if non-empty
+	if url := os.Getenv("APTIBLE_API_ROOT_URL"); url != "" {
+		ctx = context.WithValue(ctx, aptibleapi.ContextServerVariables, map[string]string{"url": url})
+	}
+
+	if m.Token == "" {
+		log.Fatalln("Could not read token: Please run aptible login or set APTIBLE_ACCESS_TOKEN")
+		return ctx
+	}
+
+	return context.WithValue(ctx, aptibleapi.ContextAPIKeys, map[string]aptibleapi.APIKey{
+		"token": {
+			Prefix: "Bearer",
+			Key:    m.Token,
+		},
+	})
 }

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -81,7 +81,7 @@ func resourceApp() *schema.Resource {
 }
 
 func resourceAppCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	envID := int64(d.Get("env_id").(int))
 	handle := d.Get("handle").(string)
 
@@ -126,7 +126,7 @@ func resourceAppImport(d *schema.ResourceData, meta interface{}) ([]*schema.Reso
 
 // syncs Terraform state with changes made via the API outside of Terraform
 func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	appID := int64(d.Get("app_id").(int))
 
 	log.Println("Getting App with ID: " + strconv.Itoa(int(appID)))
@@ -164,7 +164,7 @@ func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAppUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	appID := int64(d.Get("app_id").(int))
 
 	var diags diag.Diagnostics
@@ -240,7 +240,7 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 	readErr := resourceAppRead(d, meta)
 	if readErr == nil {
 		appID := int64(d.Get("app_id").(int))
-		client := meta.(*providerMeta).LegacyClient
+		client := meta.(*providerMetadata).LegacyClient
 		deleted, err := client.DeleteApp(appID)
 		if deleted {
 			d.SetId("")
@@ -256,7 +256,7 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func scaleServices(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	appID := int64(d.Get("app_id").(int))
 
 	// If there are no changes to services, there's no reason to scale

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -81,7 +81,7 @@ func resourceApp() *schema.Resource {
 }
 
 func resourceAppCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	envID := int64(d.Get("env_id").(int))
 	handle := d.Get("handle").(string)
 
@@ -126,7 +126,7 @@ func resourceAppImport(d *schema.ResourceData, meta interface{}) ([]*schema.Reso
 
 // syncs Terraform state with changes made via the API outside of Terraform
 func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	appID := int64(d.Get("app_id").(int))
 
 	log.Println("Getting App with ID: " + strconv.Itoa(int(appID)))
@@ -164,7 +164,7 @@ func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAppUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	appID := int64(d.Get("app_id").(int))
 
 	var diags diag.Diagnostics
@@ -240,7 +240,7 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 	readErr := resourceAppRead(d, meta)
 	if readErr == nil {
 		appID := int64(d.Get("app_id").(int))
-		client := meta.(*aptible.Client)
+		client := meta.(*providerMeta).LegacyClient
 		deleted, err := client.DeleteApp(appID)
 		if deleted {
 			d.SetId("")
@@ -256,7 +256,7 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func scaleServices(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	appID := int64(d.Get("app_id").(int))
 
 	// If there are no changes to services, there's no reason to scale

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -147,7 +147,7 @@ func TestAccResourceApp_scaleDown(t *testing.T) {
 }
 
 func testAccCheckAppDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_app" {
 			continue

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -147,7 +147,7 @@ func TestAccResourceApp_scaleDown(t *testing.T) {
 }
 
 func testAccCheckAppDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_app" {
 			continue

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -88,7 +88,7 @@ func resourceDatabase() *schema.Resource {
 }
 
 func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	envID := int64(d.Get("env_id").(int))
 	handle := d.Get("handle").(string)
 	version := d.Get("version").(string)
@@ -125,7 +125,7 @@ func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 
 // syncs Terraform state with changes made via the API outside of Terraform
 func resourceDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 
 	database, err := client.GetDatabase(databaseID)
@@ -163,7 +163,7 @@ func resourceDatabaseImport(d *schema.ResourceData, meta interface{}) ([]*schema
 
 // changes state of actual resource based on changes made in a Terraform config file
 func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 	containerSize := int64(d.Get("container_size").(int))
 	containerProfile := d.Get("container_profile").(string)
@@ -224,7 +224,7 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 
 	err := client.DeleteDatabase(databaseID)

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -88,7 +88,7 @@ func resourceDatabase() *schema.Resource {
 }
 
 func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	envID := int64(d.Get("env_id").(int))
 	handle := d.Get("handle").(string)
 	version := d.Get("version").(string)
@@ -125,7 +125,7 @@ func resourceDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
 
 // syncs Terraform state with changes made via the API outside of Terraform
 func resourceDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 
 	database, err := client.GetDatabase(databaseID)
@@ -163,7 +163,7 @@ func resourceDatabaseImport(d *schema.ResourceData, meta interface{}) ([]*schema
 
 // changes state of actual resource based on changes made in a Terraform config file
 func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 	containerSize := int64(d.Get("container_size").(int))
 	containerProfile := d.Get("container_profile").(string)
@@ -224,7 +224,7 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 
 	err := client.DeleteDatabase(databaseID)

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -184,7 +184,7 @@ func TestAccResourceDatabase_expectError(t *testing.T) {
 }
 
 func testAccCheckDatabaseDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	// Allow time for deprovision operation to complete.
 	// TODO: Replace this by waiting on the actual operation
 

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -184,7 +184,7 @@ func TestAccResourceDatabase_expectError(t *testing.T) {
 }
 
 func testAccCheckDatabaseDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	// Allow time for deprovision operation to complete.
 	// TODO: Replace this by waiting on the actual operation
 

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -150,7 +150,7 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 }
 
 func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	service := aptible.Service{}
 	var err error
 
@@ -238,7 +238,7 @@ func resourceEndpointImport(d *schema.ResourceData, meta interface{}) ([]*schema
 }
 
 func resourceEndpointRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	endpointID := int64(d.Get("endpoint_id").(int))
 
 	endpoint, err := client.GetEndpoint(endpointID)
@@ -289,7 +289,7 @@ func resourceEndpointRead(d *schema.ResourceData, meta interface{}) error {
 
 // changes state of actual resource based on changes made in a Terraform config file
 func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	endpointID := int64(d.Get("endpoint_id").(int))
 	interfaceSlice := d.Get("ip_filtering").([]interface{})
 	ipWhitelist, _ := aptible.MakeStringSlice(interfaceSlice)
@@ -313,7 +313,7 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceEndpointDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	endpointID := int64(d.Get("endpoint_id").(int))
 	err := client.DeleteEndpoint(endpointID)
 	if err != nil {

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -150,7 +150,7 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 }
 
 func resourceEndpointCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	service := aptible.Service{}
 	var err error
 
@@ -238,7 +238,7 @@ func resourceEndpointImport(d *schema.ResourceData, meta interface{}) ([]*schema
 }
 
 func resourceEndpointRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	endpointID := int64(d.Get("endpoint_id").(int))
 
 	endpoint, err := client.GetEndpoint(endpointID)
@@ -289,7 +289,7 @@ func resourceEndpointRead(d *schema.ResourceData, meta interface{}) error {
 
 // changes state of actual resource based on changes made in a Terraform config file
 func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	endpointID := int64(d.Get("endpoint_id").(int))
 	interfaceSlice := d.Get("ip_filtering").([]interface{})
 	ipWhitelist, _ := aptible.MakeStringSlice(interfaceSlice)
@@ -313,7 +313,7 @@ func resourceEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceEndpointDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	endpointID := int64(d.Get("endpoint_id").(int))
 	err := client.DeleteEndpoint(endpointID)
 	if err != nil {

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -290,7 +290,7 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 }
 
 func testAccCheckEndpointDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	// Allow time for deprovision operation to complete.
 	// TODO: Replace this by waiting on the actual operation
 

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -290,7 +290,7 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 }
 
 func testAccCheckEndpointDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	// Allow time for deprovision operation to complete.
 	// TODO: Replace this by waiting on the actual operation
 

--- a/aptible/resource_environment.go
+++ b/aptible/resource_environment.go
@@ -48,7 +48,7 @@ func resourceEnvironment() *schema.Resource {
 }
 
 func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("handle").(string)
 	stackID := int64(d.Get("stack_id").(int))
 
@@ -102,7 +102,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	envID := int64(d.Get("env_id").(int))
 
 	log.Println("Getting environment with ID: " + strconv.Itoa(int(envID)))
@@ -125,7 +125,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("handle").(string)
 	envId := int64(d.Get("env_id").(int))
 	environmentUpdates := aptible.EnvironmentUpdates{
@@ -144,7 +144,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 	readDiags := resourceEnvironmentRead(ctx, d, meta)
 	if !readDiags.HasError() {
 		envID := int64(d.Get("env_id").(int))
-		client := meta.(*aptible.Client)
+		client := meta.(*providerMeta).LegacyClient
 		err := client.DeleteEnvironment(envID)
 		if err == nil {
 			d.SetId("")

--- a/aptible/resource_environment.go
+++ b/aptible/resource_environment.go
@@ -48,7 +48,7 @@ func resourceEnvironment() *schema.Resource {
 }
 
 func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 	stackID := int64(d.Get("stack_id").(int))
 
@@ -102,7 +102,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	envID := int64(d.Get("env_id").(int))
 
 	log.Println("Getting environment with ID: " + strconv.Itoa(int(envID)))
@@ -125,7 +125,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 	envId := int64(d.Get("env_id").(int))
 	environmentUpdates := aptible.EnvironmentUpdates{
@@ -144,7 +144,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 	readDiags := resourceEnvironmentRead(ctx, d, meta)
 	if !readDiags.HasError() {
 		envID := int64(d.Get("env_id").(int))
-		client := meta.(*providerMeta).LegacyClient
+		client := meta.(*providerMetadata).LegacyClient
 		err := client.DeleteEnvironment(envID)
 		if err == nil {
 			d.SetId("")

--- a/aptible/resource_environment_test.go
+++ b/aptible/resource_environment_test.go
@@ -45,7 +45,7 @@ func TestAccResourceEnvironment_validation(t *testing.T) {
 }
 
 func testAccCheckEnvironmentDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_environment" {
 			continue

--- a/aptible/resource_environment_test.go
+++ b/aptible/resource_environment_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/aptible/go-deploy/aptible"
 )
 
 func TestAccResourceEnvironment_validation(t *testing.T) {
@@ -47,7 +45,7 @@ func TestAccResourceEnvironment_validation(t *testing.T) {
 }
 
 func testAccCheckEnvironmentDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_environment" {
 			continue

--- a/aptible/resource_log_drain.go
+++ b/aptible/resource_log_drain.go
@@ -127,7 +127,7 @@ func resourceLogDrain() *schema.Resource {
 }
 
 func resourceLogDrainCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("handle").(string)
 	accountID := int64(d.Get("env_id").(int))
 	drainType := d.Get("drain_type").(string)
@@ -173,7 +173,7 @@ func resourceLogDrainCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLogDrainRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	logDrainID := int64(d.Get("log_drain_id").(int))
 
 	log.Println("Getting log drain with ID: " + strconv.Itoa(int(logDrainID)))
@@ -220,7 +220,7 @@ func resourceLogDrainDelete(d *schema.ResourceData, meta interface{}) error {
 	readErr := resourceLogDrainRead(d, meta)
 	if readErr == nil {
 		logDrainID := int64(d.Get("log_drain_id").(int))
-		client := meta.(*aptible.Client)
+		client := meta.(*providerMeta).LegacyClient
 		deleted, err := client.DeleteLogDrain(logDrainID)
 		if deleted {
 			d.SetId("")

--- a/aptible/resource_log_drain.go
+++ b/aptible/resource_log_drain.go
@@ -127,7 +127,7 @@ func resourceLogDrain() *schema.Resource {
 }
 
 func resourceLogDrainCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 	accountID := int64(d.Get("env_id").(int))
 	drainType := d.Get("drain_type").(string)
@@ -173,7 +173,7 @@ func resourceLogDrainCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceLogDrainRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	logDrainID := int64(d.Get("log_drain_id").(int))
 
 	log.Println("Getting log drain with ID: " + strconv.Itoa(int(logDrainID)))
@@ -220,7 +220,7 @@ func resourceLogDrainDelete(d *schema.ResourceData, meta interface{}) error {
 	readErr := resourceLogDrainRead(d, meta)
 	if readErr == nil {
 		logDrainID := int64(d.Get("log_drain_id").(int))
-		client := meta.(*providerMeta).LegacyClient
+		client := meta.(*providerMetadata).LegacyClient
 		deleted, err := client.DeleteLogDrain(logDrainID)
 		if deleted {
 			d.SetId("")

--- a/aptible/resource_log_drain_test.go
+++ b/aptible/resource_log_drain_test.go
@@ -225,7 +225,7 @@ func TestAccResourceLogDrain_papertrail(t *testing.T) {
 }
 
 func testAccCheckLogDrainDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_log_drain" {
 			continue

--- a/aptible/resource_log_drain_test.go
+++ b/aptible/resource_log_drain_test.go
@@ -225,7 +225,7 @@ func TestAccResourceLogDrain_papertrail(t *testing.T) {
 }
 
 func testAccCheckLogDrainDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_log_drain" {
 			continue

--- a/aptible/resource_metric_drain.go
+++ b/aptible/resource_metric_drain.go
@@ -130,7 +130,7 @@ func resourceMetricDrainValidate(_ context.Context, diff *schema.ResourceDiff, _
 }
 
 func resourceMetricDrainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("handle").(string)
 	accountID := int64(d.Get("env_id").(int))
 	data := &aptible.MetricDrainCreateAttrs{
@@ -156,7 +156,7 @@ func resourceMetricDrainCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceMetricDrainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	metricDrainID := int64(d.Get("metric_drain_id").(int))
 
 	log.Println("Getting metric drain with ID: " + strconv.Itoa(int(metricDrainID)))
@@ -189,7 +189,7 @@ func resourceMetricDrainDelete(ctx context.Context, d *schema.ResourceData, meta
 	readDiags := resourceMetricDrainRead(ctx, d, meta)
 	if !readDiags.HasError() {
 		metricDrainID := int64(d.Get("metric_drain_id").(int))
-		client := meta.(*aptible.Client)
+		client := meta.(*providerMeta).LegacyClient
 		deleted, err := client.DeleteMetricDrain(metricDrainID)
 		if deleted {
 			d.SetId("")

--- a/aptible/resource_metric_drain.go
+++ b/aptible/resource_metric_drain.go
@@ -130,7 +130,7 @@ func resourceMetricDrainValidate(_ context.Context, diff *schema.ResourceDiff, _
 }
 
 func resourceMetricDrainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 	accountID := int64(d.Get("env_id").(int))
 	data := &aptible.MetricDrainCreateAttrs{
@@ -156,7 +156,7 @@ func resourceMetricDrainCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceMetricDrainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	metricDrainID := int64(d.Get("metric_drain_id").(int))
 
 	log.Println("Getting metric drain with ID: " + strconv.Itoa(int(metricDrainID)))
@@ -189,7 +189,7 @@ func resourceMetricDrainDelete(ctx context.Context, d *schema.ResourceData, meta
 	readDiags := resourceMetricDrainRead(ctx, d, meta)
 	if !readDiags.HasError() {
 		metricDrainID := int64(d.Get("metric_drain_id").(int))
-		client := meta.(*providerMeta).LegacyClient
+		client := meta.(*providerMetadata).LegacyClient
 		deleted, err := client.DeleteMetricDrain(metricDrainID)
 		if deleted {
 			d.SetId("")

--- a/aptible/resource_metric_drain_test.go
+++ b/aptible/resource_metric_drain_test.go
@@ -262,7 +262,7 @@ func TestAccResourceMetricDrain_datadog(t *testing.T) {
 }
 
 func testAccCheckMetricDrainDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_metric_drain" {
 			continue

--- a/aptible/resource_metric_drain_test.go
+++ b/aptible/resource_metric_drain_test.go
@@ -262,7 +262,7 @@ func TestAccResourceMetricDrain_datadog(t *testing.T) {
 }
 
 func testAccCheckMetricDrainDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "aptible_metric_drain" {
 			continue

--- a/aptible/resource_replica.go
+++ b/aptible/resource_replica.go
@@ -59,7 +59,7 @@ func resourceReplica() *schema.Resource {
 }
 
 func resourceReplicaCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 
 	attrs := aptible.ReplicateAttrs{
@@ -91,7 +91,7 @@ func resourceReplicaImport(d *schema.ResourceData, meta interface{}) ([]*schema.
 
 // syncs Terraform state with changes made via the API outside of Terraform
 func resourceReplicaRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	replica, err := client.GetReplica(replicaID)
 	if err != nil {
@@ -117,7 +117,7 @@ func resourceReplicaRead(d *schema.ResourceData, meta interface{}) error {
 
 // changes state of actual resource based on changes made in a Terraform config file
 func resourceReplicaUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	containerSize := int64(d.Get("container_size").(int))
 	diskSize := int64(d.Get("disk_size").(int))
@@ -141,7 +141,7 @@ func resourceReplicaUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceReplicaDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*providerMeta).LegacyClient
+	client := meta.(*providerMetadata).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	err := client.DeleteReplica(replicaID)
 	if err != nil {

--- a/aptible/resource_replica.go
+++ b/aptible/resource_replica.go
@@ -59,7 +59,7 @@ func resourceReplica() *schema.Resource {
 }
 
 func resourceReplicaCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	handle := d.Get("handle").(string)
 
 	attrs := aptible.ReplicateAttrs{
@@ -91,7 +91,7 @@ func resourceReplicaImport(d *schema.ResourceData, meta interface{}) ([]*schema.
 
 // syncs Terraform state with changes made via the API outside of Terraform
 func resourceReplicaRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	replica, err := client.GetReplica(replicaID)
 	if err != nil {
@@ -117,7 +117,7 @@ func resourceReplicaRead(d *schema.ResourceData, meta interface{}) error {
 
 // changes state of actual resource based on changes made in a Terraform config file
 func resourceReplicaUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	containerSize := int64(d.Get("container_size").(int))
 	diskSize := int64(d.Get("disk_size").(int))
@@ -141,7 +141,7 @@ func resourceReplicaUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceReplicaDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*aptible.Client)
+	client := meta.(*providerMeta).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	err := client.DeleteReplica(replicaID)
 	if err != nil {

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -122,7 +122,7 @@ func TestAccResourceReplica_expectError(t *testing.T) {
 }
 
 func testAccCheckReplicaDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*aptible.Client)
+	client := testAccProvider.Meta().(*providerMeta).LegacyClient
 	// Allow time for deprovision operation to complete.
 	// TODO: Replace this by waiting on the actual operation
 

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -122,7 +122,7 @@ func TestAccResourceReplica_expectError(t *testing.T) {
 }
 
 func testAccCheckReplicaDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*providerMeta).LegacyClient
+	client := testAccProvider.Meta().(*providerMetadata).LegacyClient
 	// Allow time for deprovision operation to complete.
 	// TODO: Replace this by waiting on the actual operation
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/aptible/aptible-api-go v0.1.0
 	github.com/aptible/go-deploy v0.5.2
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/aptible/aptible-api-go v0.1.0 h1:UkOL2TuIylvnvwERXvkcXN/SlukXjNFYh/50OOnm/PQ=
+github.com/aptible/aptible-api-go v0.1.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/go-deploy v0.5.2 h1:cmPawI9esyBkQ7009UR7z3I2AWgzsWtnBz7HKKjImao=
 github.com/aptible/go-deploy v0.5.2/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Using a custom provider metadata struct allows us more flexibility to modify the struct such as using multiple clients.