### PR TITLE
Default action must be explicit.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "latest"
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
The binary `goreleaser` binary runs `release` by default, but the action requires you to pass args, so we'll just do that.