### PR TITLE
ServiceSizingPolicy

### DIFF
--- a/aptible/client_utils.go
+++ b/aptible/client_utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/aptible/go-deploy/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -80,4 +81,13 @@ func generateErrorFromClientError(abstractedError interface{}) error {
 
 func generateDiagnosticsFromClientError(abstractedError interface{}) diag.Diagnostics {
 	return errorToDiagnostics(generateErrorFromClientError(abstractedError))
+}
+
+// When turning float32 into float64 normally, the change in precision causes values to change slightly
+// This function avoids that by first turning the value into a string and then turning it into a float64
+// WARNING: This function will only keep 6 decimals!
+func formatFloat32ToFloat64(val float32) float64 {
+	formatted := fmt.Sprintf("%.6f", val)
+	result, _ := strconv.ParseFloat(formatted, 64)
+	return result
 }

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -99,7 +99,6 @@ func resourceService() *schema.Resource {
 			"service_sizing_policy": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				MaxItems: 1,
 				Elem:     resourceServiceSizingPolicy(),
 			},
 		},
@@ -223,7 +222,7 @@ func validateServiceSizingPolicy(ctx context.Context, d *schema.ResourceDiff, _ 
 		serviceMap := service.(map[string]interface{})
 		if policy, ok := serviceMap["service_sizing_policy"]; ok {
 			policies := policy.(*schema.Set).List() // should only be one, but yes it's a Set
-			if len(policies) > 0 && policies[0] != nil {
+			if len(policies) == 1 && policies[0] != nil {
 				policyMap := policies[0].(map[string]interface{})
 				autoscalingType := policyMap["autoscaling_type"].(string)
 				attrsToCheck := []string{
@@ -258,6 +257,8 @@ func validateServiceSizingPolicy(ctx context.Context, d *schema.ResourceDiff, _ 
 						}
 					}
 				}
+			} else if len(policies) > 0 {
+				return fmt.Errorf("only one service_sizing_policy is allowed per service")
 			}
 		}
 	}

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -793,10 +793,18 @@ func updateServiceSizingPolicy(ctx context.Context, d *schema.ResourceData, meta
 			if err != nil {
 				return err
 			}
-			// Don't even check, just delete
-			_, err = client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
+			// In order to delete, we must first see if there's one associated on the API, otherwise we get an error
+			policy, err := findServiceSizingPolicyForService(serviceId, ctx, meta)
 			if err != nil {
-				return fmt.Errorf("failed to delete sizing policy for service %s: %w", serviceName, err)
+				log.Println(err)
+				return err
+			}
+			if policy != nil {
+				// Now delete
+				_, err = client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
+				if err != nil {
+					return fmt.Errorf("failed to delete sizing policy for service %s: %w", serviceName, err)
+				}
 			}
 		}
 	}

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -793,7 +793,10 @@ func updateServiceSizingPolicy(ctx context.Context, d *schema.ResourceData, meta
 				return err
 			}
 			// Don't even check, just delete
-			client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
+			_, err = client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
+			if err != nil {
+				return fmt.Errorf("failed to delete sizing policy for service %s: %w", serviceName, err)
+			}
 		}
 	}
 	return nil

--- a/docs/index.md
+++ b/docs/index.md
@@ -142,6 +142,39 @@ resource "aptible_app" "APP" {
 }
 ```
 
+#### Autoscaling
+
+Services can be configured to [Autoscale](https://www.aptible.com/docs/core-concepts/scaling/app-scaling)
+either vertically or horizontally. The configuration is per service
+
+```hcl
+resource "aptible_app" "APP" {
+    env_id = ENVIRONMENT_ID
+    handle = "APP_HANDLE"
+    service {
+        process_type = "SERVICE_NAME1"
+        container_count = 1
+        container_memory_limit = 1024
+        service_sizing_policy {
+            autoscaling_type = "horizontal"
+            min_containers = 2
+            max_container = 5
+            min_cpu_threshold = 0.4
+            max_cpu_threshold = 0.8
+        }
+    }
+    service {
+        process_type = "SERVICE_NAME2"
+        container_count = 2
+        container_memory_limit = 2048
+        service_sizing_policy {
+            autoscaling_type = "vertical"
+            mem_scale_up_threshold = 0.8
+        }
+    }
+}
+```
+
 ### Endpoints
 
 Endpoints for [Apps](https://www.aptible.com/docs/core-concepts/apps) and

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -108,8 +108,10 @@ The `service_sizing_policy` block supports:
 - `maximum_memory` - Vertical autoscaling only - Defines the upper memory threshold,
   capping the maximum memory allocation possible through Autoscaler. If blank,
   the container can scale to the largest size available.
-- `min_cpu_threshold` - Horizontal autoscaling only - 
-- `max_cpu_threshold` - Horizontal autoscaling only - 
+- `min_cpu_threshold` - Horizontal autoscaling only - Specifies the percentage of the current CPU usage at which
+  a down-scaling action is triggered.
+- `max_cpu_threshold` - Horizontal autoscaling only - Specifies the percentage of the current CPU usage at which
+  an up-scaling action is triggered.
 - `min_containers` - Horizontal autoscaling only - Sets the lowest container count to which
   the service can be scaled down by Autoscaler.
 - `max_containers` - Horizontal autoscaling only - Sets the highest container count to which

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -37,6 +37,13 @@ resource "aptible_app" "APP" {
         container_count = 2
         container_memory_limit = 2048
         force_zero_downtime = true
+        service_sizing_policy {
+          autoscaling_type = "horizontal"
+          min_containers = 2
+          max_container = 5
+          min_cpu_threshold = 0.4
+          max_cpu_threshold = 0.8
+        }
     }
 }
 ```
@@ -73,6 +80,44 @@ The `service` block supports:
   [For more information please see the docs](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/releases/overview).
 - `simple_health_check` - (Default: false) For services without endpoints, if
   force_zero_downtime is enabled, do a simple uptime check instead of using docker healthchecks.
+- `service_sizing_policy` - (Optional) A block to manage autoscaling for services. See
+  the main provider docs for additional details.
+
+The `service_sizing_policy` block supports:
+
+- `autoscaling_type` - The type of autoscaling. Must be either `horizontal` or `vertical`.
+- `metric_lookback_seconds` - (Default: 1800) The duration in seconds for 
+  retrieving past performance metrics.
+- `percentile` - (Default: 99) The percentile for evaluating metrics.
+- `post_scale_up_cooldown_seconds` - (Default: 60) The waiting period in seconds after an automated
+ scale-up before another scaling action can be considered.
+- `post_scale_down_cooldown_seconds` - (Default: 300) The waiting period in seconds after an automated
+ scale-down before another scaling action can be considered.
+- `post_release_cooldown_seconds` - (Default: 300) The time in seconds to wait following a
+  deploy before another scaling action can be considered.
+- `mem_cpu_ratio_r_threshold` - (Default: 4.0) Establishes the ratio of Memory (in GB) to CPU (in CPUs)
+  at which values exceeding the threshold prompt a shift to an R (Memory Optimized) profile.
+- `mem_cpu_ratio_c_threshold` - (Default: 2.0) Sets the Memory-to-CPU ratio threshold,
+  below which the service is transitioned to a C (Compute Optimized) profile.
+- `mem_scale_up_threshold` - (Default: 0.9) Vertical autoscaling only - Specifies the percentage
+  of the current memory limit at which the service’s memory usage triggers an up-scaling action.
+- `mem_scale_down_threshold` - (Default: 0.75) Vertical autoscaling only - Specifies the percentage
+  of the current memory limit at which the service’s memory usage triggers a down-scaling action.
+- `minimum_memory` - (Default: 2048) Vertical autoscaling only - Sets the lowest memory
+  limit to which the service can be scaled down by Autoscaler.
+- `maximum_memory` - Vertical autoscaling only - Defines the upper memory threshold,
+  capping the maximum memory allocation possible through Autoscaler. If blank,
+  the container can scale to the largest size available.
+- `min_cpu_threshold` - Horizontal autoscaling only - 
+- `max_cpu_threshold` - Horizontal autoscaling only - 
+- `min_containers` - Horizontal autoscaling only - Sets the lowest container count to which
+  the service can be scaled down by Autoscaler.
+- `max_containers` - Horizontal autoscaling only - Sets the highest container count to which
+  the service can be scaled up to by Autoscaler.
+- `scale_up_step` - (Default: 1) Horizontal autoscaling only - Sets the amount of containers to add
+  when autoscaling (ex: a value of 2 will go from 1->3->5). Container count will never exceed the configured maximum.
+- `scale_down_step` - (Default: 1) Horizontal autoscaling only - Sets the amount of containers to remove when
+  autoscaling (ex: a value of 2 will go from 4->2->1). Container count will never exceed the configured minimum.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/aptible/aptible-api-go v0.3.0
+	github.com/aptible/aptible-api-go v0.4.0
 	github.com/aptible/go-deploy v0.5.3
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/aptible/aptible-api-go v0.3.0 h1:fko5TnKJ7t1PrXOdO6T1GIQQsA7Rkyhe8LS5M5kw0BM=
-github.com/aptible/aptible-api-go v0.3.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
+github.com/aptible/aptible-api-go v0.4.0 h1:G14BjhMb702VDFHX0+aQWBNaDfFzm365HEB05ggOig4=
+github.com/aptible/aptible-api-go v0.4.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/go-deploy v0.5.3 h1:fNUakAsvjfWJ3Gk+fpC/JGTXKb3l2PwlzV1143Z4+cA=
 github.com/aptible/go-deploy v0.5.3/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Allows creating a ServiceSizingPolicy per Service

Integrated tests pass: (unable to show full command due to secrets)
![image](https://github.com/user-attachments/assets/c1333253-7b97-498a-8616-79816e089589)

### How to test

For the full battery of related tests:
`TF_ACC=1 APTIBLE_AUTH_ROOT_URL=[your-auth] APTIBLE_API_ROOT_URL=[your-api] APTIBLE_ACCESS_TOKEN=[your-token] APTIBLE_ORGANIZATION_ID=[your-org] APTIBLE_STACK_ID=[your-stack] go test -run "^(TestAccResourceApp_basic|TestAccResourceApp_deploy|TestAccResourceApp_multiple_services|TestAccResourceApp_updateConfig|TestAccResourceApp_scaleDown|TestAccResourceApp_serviceSizingPolicy|TestAccResourceApp_updateServiceSizingPolicy|TestAccResourceApp_autoscalingTypeHorizontalMissingAttributes|TestAccResourceApp_invalidAutoscalingType|TestAccResourceApp_removeServiceSizingPolicy|TestAccResourceApp_autoscalingTypeVerticalInvalidAttributes|TestAccResourceApp_moreThanOnePolicy)$" github.com/aptible/terraform-provider-aptible/aptible`