### PR TITLE
Add missing support for InfluxDB v2 metric drains

### DIFF
--- a/aptible/resource_metric_drain.go
+++ b/aptible/resource_metric_drain.go
@@ -72,6 +72,16 @@ func resourceMetricDrain() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"bucket": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"organization": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"api_key": {
 				Type:      schema.TypeString,
 				Optional:  true,
@@ -88,7 +98,7 @@ func resourceMetricDrain() *schema.Resource {
 	}
 }
 
-var validMetricDrainTypes = []string{"influxdb_database", "influxdb", "datadog"}
+var validMetricDrainTypes = []string{"influxdb_database", "influxdb", "influxdb2", "datadog"}
 
 var metricDrainAttrs = map[string]ResourceAttrs{
 	"influxdb_database": {
@@ -98,6 +108,10 @@ var metricDrainAttrs = map[string]ResourceAttrs{
 	"influxdb": {
 		Required:   []string{"url", "username", "password", "database"},
 		NotAllowed: []string{"database_id"},
+	},
+	"influxdb2": {
+		Required:   []string{"url", "api_key", "bucket", "organization"},
+		NotAllowed: []string{"database_id", "username", "password"},
 	},
 	"datadog": {
 		Required:   []string{"api_key"},
@@ -141,6 +155,9 @@ func resourceMetricDrainCreate(ctx context.Context, d *schema.ResourceData, meta
 		Password:   d.Get("password").(string),
 		Database:   d.Get("database").(string),
 		APIKey:     d.Get("api_key").(string),
+		AuthToken:  d.Get("api_key").(string),
+		Bucket:     d.Get("bucket").(string),
+		Org:        d.Get("organization").(string),
 		SeriesURL:  strfmt.URI(d.Get("series_url").(string)),
 	}
 
@@ -179,8 +196,15 @@ func resourceMetricDrainRead(_ context.Context, d *schema.ResourceData, meta int
 	_ = d.Set("username", metricDrain.Username)
 	_ = d.Set("password", metricDrain.Password)
 	_ = d.Set("database", metricDrain.Database)
-	_ = d.Set("api_key", metricDrain.APIKey)
+	if metricDrain.APIKey != "" {
+		_ = d.Set("api_key", metricDrain.APIKey)
+	}
 	_ = d.Set("series_url", metricDrain.SeriesURL)
+	if metricDrain.AuthToken != "" {
+		_ = d.Set("api_key", metricDrain.AuthToken)
+	}
+	_ = d.Set("bucket", metricDrain.Bucket)
+	_ = d.Set("organization", metricDrain.Org)
 
 	return nil
 }

--- a/docs/resources/metric_drain.md
+++ b/docs/resources/metric_drain.md
@@ -17,7 +17,7 @@ resource "aptible_metric_drain" "influxdb_database_drain" {
 }
 ```
 
-### InfluxDB
+### InfluxDB (v1)
 
 ```hcl
 resource "aptible_metric_drain" "influxdb_drain" {
@@ -28,6 +28,20 @@ resource "aptible_metric_drain" "influxdb_drain" {
   username   = "example_user"
   password   = "example_password"
   database   = "metrics"
+}
+```
+
+### InfluxDB (v2)
+
+```hcl
+resource "aptible_metric_drain" "influxdb_drain" {
+  env_id       = data.aptible_environment.example.env_id
+  drain_type   = "influxdb2"
+  handle       = "influxdb-metric-drain"
+  url          = "https://influx.example.com:443"
+  api_key      = "xxxxx-xxxxx-xxxxx"
+  bucket       = "yourBucket"
+  organization = "myOrg"
 }
 ```
 
@@ -54,12 +68,14 @@ resource "aptible_metric_drain" "datadog_drain" {
   `influxdb_database` drains to send metrics to.
 - `url` - The URL (scheme, host, and port) for `influxdb` drains to send metrics
   to.
-- `username` - The user for `influxdb` drains to use for authentication.
-- `password` - The password for `influxdb` drains to use for authentication.
+- `username` - The user for `influxdb v1` drains to use for authentication.
+- `password` - The password for `influxdb v1` drains to use for authentication.
 - `database` - The
-  [InfluxDB database](https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#database)
+  [InfluxDB v1 database](https://docs.influxdata.com/influxdb/v1.8/concepts/glossary/#database)
   for `influxdb` drains to send the metrics to.
-- `api_key` - The API key for `datadog` drains to use for authentication.
+- `bucket` - The bucket for `influxdb v2` drains to use.
+- `organization` - The InfluxDB organization for `influxdb v2` drains to use.
+- `api_key` - The API key for `datadog` or `influxdb v2` drains to use for authentication.
 - `series_url` (Optional) - The series API URL for `datadog` drains to send
   metrics to. Examples: `https://app.datadoghq.com/api/v1/series`,
   `https://us3.datadoghq.com/api/v1/series`,
@@ -84,6 +100,13 @@ All `aptible_metric_drain` resources require the following attributes:
 - `username` (Required)
 - `password` (Required)
 - `database` (Required)
+
+#### `influxdb2`
+
+- `url` (Required)
+- `api_key` (Required)
+- `bucket` (Required)
+- `organization` (Required)
 
 #### `datadog`
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/aptible/aptible-api-go v0.4.0
-	github.com/aptible/go-deploy v0.5.3
+	github.com/aptible/go-deploy v0.5.4
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.38.67 // indirect
 	github.com/bflad/tfproviderdocs v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/aptible/aptible-api-go v0.4.0 h1:G14BjhMb702VDFHX0+aQWBNaDfFzm365HEB05ggOig4=
 github.com/aptible/aptible-api-go v0.4.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
-github.com/aptible/go-deploy v0.5.3 h1:fNUakAsvjfWJ3Gk+fpC/JGTXKb3l2PwlzV1143Z4+cA=
-github.com/aptible/go-deploy v0.5.3/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
+github.com/aptible/go-deploy v0.5.4 h1:fUXkJ5kzJhl2alknsV7OndpHirLIXHd8l8Zp6bhIlL0=
+github.com/aptible/go-deploy v0.5.4/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
TODO:
- [x] Once https://github.com/aptible/go-deploy/pull/70 is merged, update client here

NOTE: I am re-using `api_key` as the user-visible attribute. Is this ok, or should I use `auth_token` instead?

Tested by manually editing vendored files for now, results:
![image](https://github.com/user-attachments/assets/4a3dcc02-ba3f-4ee4-8f6d-012319c8291f)
ran with `TF_ACC=1 [SNIPPED] test -run "^(TestAccResourceMetricDrain_.*)$" github.com/aptible/terraform-provider-aptible/aptible`

Another test run after updating the client, same command:
![image](https://github.com/user-attachments/assets/4ef0ff51-8a0e-487c-8681-36a07258d54b)
