### PR TITLE
fix(app): schema should drive whether we should crud sizing policy

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -781,8 +781,9 @@ func updateServiceSizingPolicy(ctx context.Context, d *schema.ResourceData, meta
 			return err
 		}
 
-		// no policy in the schema but policy exists in deploy-api? delete
+		// no policy in the schema
 		if len(schemaPolicies) == 0 {
+			// policy exists in deploy-api? delete
 			if policy != nil {
 				_, err = client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
 				if err != nil {

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -782,10 +782,12 @@ func updateServiceSizingPolicy(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		// no policy in the schema but policy exists in deploy-api? delete
-		if len(schemaPolicies) == 0 && policy != nil {
-			_, err = client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
-			if err != nil {
-				return fmt.Errorf("failed to delete autoscaling policy for service %s: %w", serviceName, err)
+		if len(schemaPolicies) == 0 {
+			if policy != nil {
+				_, err = client.ServiceSizingPoliciesAPI.DeleteServiceSizingPolicy(ctx, serviceId).Execute()
+				if err != nil {
+					return fmt.Errorf("failed to delete autoscaling policy for service %s: %w", serviceName, err)
+				}
 			}
 			return nil
 		}


### PR DESCRIPTION
We were using a boolean `update` to determine whether we should create or update a service sizing policy associated with a service.  This boolean was set whether an App was being created or updated.  This is flawed logic because an App can exist with autoscaling enable, disabled, or toggled between the two states.  Therefore, we need to be able to crud a service sizing policy regardless if an App is being created or updated.

This change removes the boolean `update` and adjust the service sizing crud based on whether a service sizing policy exists in `deploy-api` or not.

Reference: https://app.shortcut.com/aptible/story/30748/bug-report-if-a-deployed-app-service-has-autoscaling-disabled-you-cannot-apply-or-update-the-autos

Reference: https://aptible.slack.com/archives/C05CMUW3LHX/p1738106392124669

# Test on `master`

```bash
Done!
    resource_app_test.go:197: Step 3/4 error: Error running apply: exit status 1

        Error: There was an error when trying to update autoscaling_policy.

          with aptible_app.test,
          on terraform_plugin_test.tf line 9, in resource "aptible_app" "test":
           9:   resource "aptible_app" "test" {

        failed to create autoscaling policy for service cmd: 403 Forbidden - Access
        Denied
Still creating...
--- FAIL: TestAccResourceApp_autoscalingDisabledThenEnabled (105.02s)
FAIL
FAIL    github.com/aptible/terraform-provider-aptible/aptible   105.834s
FAIL
make: *** [testacc] Error 1
```