### PR TITLE
Deprovsion tail log drain before deleting the environment

### DIFF
--- a/aptible/resource_environment.go
+++ b/aptible/resource_environment.go
@@ -225,12 +225,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 					return nil
 				}
 
-				deleted, err := client.DeleteLogDrain(drain.ID)
-
-				if deleted {
-					d.SetId("")
-					return nil
-				}
+				_, err := client.DeleteLogDrain(drain.ID)
 
 				if err != nil {
 					log.Println("There was an error when completing the request to destroy the log drain.\n[ERROR] -", err)

--- a/aptible/resource_environment.go
+++ b/aptible/resource_environment.go
@@ -200,7 +200,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 		client := meta.(*providerMetadata).LegacyClient
 
 		// First we need to run deprovision operations on any tail drains
-		log.Printf("Checking for an tail type log drain for environment ID: %d\n", envID)
+		log.Println("Checking for an tail type log drain for environment ID: ", envID)
 
 		resp, err := client.ListLogDrainsForAccount(envID)
 
@@ -216,12 +216,12 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 
 		drains := resp.Embedded.LogDrains
 		if len(drains) == 0 {
-			log.Printf("No log drains found")
+			log.Println("No log drains found")
 			return nil
 		} else {
 			for _, drain := range drains {
 				if drain.DrainType != "tail" {
-					log.Printf("Found drain of unexpected type: %d\n", drain.DrainType)
+					log.Println("Found drain of unexpected type: ", drain.DrainType)
 					return nil
 				}
 

--- a/aptible/resource_environment.go
+++ b/aptible/resource_environment.go
@@ -202,14 +202,14 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 		// First we need to run deprovision operations on any tail drains
 		log.Println("Checking for an tail type log drain for environment ID: ", envID)
 
-		resp, err := client.ListLogDrainsForAccount(envID)
+		resp, listErr := client.ListLogDrainsForAccount(envID)
 
-		if err != nil {
+		if listErr != nil {
 			return diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Error,
 					Summary:  "Error fetching log drains",
-					Detail:   err.Error(),
+					Detail:   listErr.Error(),
 				},
 			}
 		}
@@ -225,11 +225,11 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 					return nil
 				}
 
-				_, err := client.DeleteLogDrain(drain.ID)
+				_, drainErr := client.DeleteLogDrain(drain.ID)
 
-				if err != nil {
-					log.Println("There was an error when completing the request to destroy the log drain.\n[ERROR] -", err)
-					return generateErrorFromClientError(err)
+				if drainErr != nil {
+					log.Println("There was an error when completing the request to destroy the log drain.\n[ERROR] -", drainErr)
+					return generateDiagnosticsFromClientError(drainErr)
 				}
 			}
 		}


### PR DESCRIPTION
This deletes any "tail" type log drains created by use of the `aptible logs` command before destroying the Environment.
Users are still responsible for cleaning up other resources that may prevent Environment deletion (backups, other types of log drains, etc)

https://app.shortcut.com/aptible/story/29934/automatically-deprovision-log-tail-log-drains-when-deprovisioning-environments