### PR TITLE
Stop timeout configuration on services

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -80,6 +80,7 @@ The `service` block supports:
   [For more information please see the docs](https://www.aptible.com/docs/core-concepts/apps/deploying-apps/releases/overview).
 - `simple_health_check` - (Default: false) For services without endpoints, if
   force_zero_downtime is enabled, do a simple uptime check instead of using docker healthchecks.
+- `stop_timeout` - (Default: 10) The number of seconds to wait for the service containers to stop gracefully on release before killing it.
 - `service_sizing_policy` - **Deprecated** (Optional) A block to manage autoscaling for services. See
   the main provider docs for additional details.
 - `autoscaling_policy` - (Optional) A block to manage autoscaling for services. See

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.1
 
 require (
-	github.com/aptible/aptible-api-go v0.6.0
+	github.com/aptible/aptible-api-go v0.6.1-0.20250509114037-4e256be944a8
 	github.com/aptible/go-deploy v0.5.4
 	github.com/bflad/tfproviderdocs v0.9.1
 	github.com/bflad/tfproviderlint v0.28.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.1
 
 require (
-	github.com/aptible/aptible-api-go v0.6.1-0.20250509114037-4e256be944a8
+	github.com/aptible/aptible-api-go v0.7.0
 	github.com/aptible/go-deploy v0.5.4
 	github.com/bflad/tfproviderdocs v0.9.1
 	github.com/bflad/tfproviderlint v0.28.1

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aptible/aptible-api-go v0.6.1-0.20250509114037-4e256be944a8 h1:kSjGA4xuT9k/ypyTXrFl5IFIg1nt2Yxw8FYjeusXock=
-github.com/aptible/aptible-api-go v0.6.1-0.20250509114037-4e256be944a8/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
+github.com/aptible/aptible-api-go v0.7.0 h1:CIwKRejrCDjNQvBfW76lZAD0UjUTpMFBoc1p0DyYubk=
+github.com/aptible/aptible-api-go v0.7.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/go-deploy v0.5.4 h1:fUXkJ5kzJhl2alknsV7OndpHirLIXHd8l8Zp6bhIlL0=
 github.com/aptible/go-deploy v0.5.4/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aptible/aptible-api-go v0.6.0 h1:W2u4gGWFrcQaYSEXUc8I+ieg6QGrjSEJJ/62V8sBDpM=
-github.com/aptible/aptible-api-go v0.6.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
+github.com/aptible/aptible-api-go v0.6.1-0.20250509114037-4e256be944a8 h1:kSjGA4xuT9k/ypyTXrFl5IFIg1nt2Yxw8FYjeusXock=
+github.com/aptible/aptible-api-go v0.6.1-0.20250509114037-4e256be944a8/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/go-deploy v0.5.4 h1:fUXkJ5kzJhl2alknsV7OndpHirLIXHd8l8Zp6bhIlL0=
 github.com/aptible/go-deploy v0.5.4/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
~Needs to wait for the actual update to https://github.com/aptible/aptible-api-go to update the client to a released version, but as a preview for now:~

Allows configuring stop timeout. Since setting null is a bit of a headache here, I think having the default set to 10 is fine, since that just replicates the default behavior anyways. In theory the app's stack setting could be set differently so 10 isn't their actual default, but hopefully we'll work on deprecating that stack setting, so that shouldn't be true for much longer.