### PR TITLE
Fix stop timeout tests

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -395,6 +395,9 @@ func resourceAppRead(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("ZDD flags: %t, %t", s.ForceZeroDowntime, s.NaiveHealthCheck)
 		service["force_zero_downtime"] = s.ForceZeroDowntime
 		service["simple_health_check"] = s.NaiveHealthCheck
+		if s.StopTimeout.IsSet() && s.StopTimeout.Get() != nil {
+			service["stop_timeout"] = *s.StopTimeout.Get()
+		}
 		// Find service_sizing_policy if any
 		var policy *aptibleapi.ServiceSizingPolicy
 		policy, err = getServiceSizingPolicyForService(s.Id, ctx, meta)

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -434,7 +434,7 @@ func TestAccResourceApp_stopTimeout(t *testing.T) {
 			CheckDestroy: testAccCheckAppDestroy,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccAptibleAppDeploy(rHandle, "16"),
+					Config: testAccAptibleAppDeployStopTimeout(rHandle, "16"),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttrPair("aptible_environment.test", "env_id", "aptible_app.test", "env_id"),
 						resource.TestCheckResourceAttr("aptible_app.test", "handle", rHandle),
@@ -522,6 +522,35 @@ func testAccAptibleAppDeploy(handle string, index string) string {
 			container_count = 1
 			force_zero_downtime = true
 			simple_health_check = true
+		}
+	}
+	`, handle, testOrganizationId, testStackId, handle, index)
+}
+
+func testAccAptibleAppDeployStopTimeout(handle string, index string) string {
+	return fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_app" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		config = {
+			"APTIBLE_DOCKER_IMAGE" = "quay.io/aptible/nginx-mirror:%s"
+			"WHATEVER" = "something"
+			"OOPS" = "mistake"
+		}
+    service {
+			process_type = "cmd"
+			container_profile = "m5"
+			container_memory_limit = 512
+			container_count = 1
+			force_zero_downtime = true
+			simple_health_check = true
+			stop_timeout = 60
 		}
 	}
 	`, handle, testOrganizationId, testStackId, handle, index)


### PR DESCRIPTION
2 issues: first was that the test wasn't actually setting the stop timeout correctly, and second is that we weren't setting state correctly. For the state, technically I think we only need the IsSet() check but I wasn't 100% sure so I left both checks there.