### PR TITLE
Add load_balancing_algorithm_type to Endpoint resource

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -134,7 +134,6 @@ func resourceEndpoint() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(validLbAlgorithms, false),
-				Default:      "round_robin",
 			},
 		},
 	}

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -130,6 +130,12 @@ func resourceEndpoint() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"load_balancing_algorithm_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(validLbAlgorithms, false),
+				Default:      "round_robin",
+			},
 		},
 	}
 }
@@ -140,6 +146,8 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 	containerPorts, _ := aptible.MakeInt64Slice(interfaceContainerPortsSlice)
 	containerPort, _ := (d.Get("container_port").(int))
 	endpointType := d.Get("endpoint_type").(string)
+	platform := d.Get("platform").(string)
+	lbAlgorithmType := d.Get("load_balancing_algorithm_type").(string)
 	var err error
 
 	// container_port and container ports are mutually exclusive fields
@@ -154,6 +162,11 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 	// container ports can only be used with tls/tcp
 	if len(containerPorts) != 0 && (endpointType == "https" || endpointType == "grpc") {
 		err = multierror.Append(err, fmt.Errorf("do not specify container ports with %s endpoint (see terraform docs)", endpointType))
+	}
+
+	// load balancing algorithm can only be used with ALBs
+	if (lbAlgorithmType != "round_robin") && (platform != "alb") {
+		err = multierror.Append(err, fmt.Errorf("do not specify a load balancing algorithm with %s endpoint", platform))
 	}
 
 	return err
@@ -271,6 +284,7 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 	attrs.SetDefault(defaultDomain)
 	attrs.SetAcme(managed)
 	attrs.SetShared(shared)
+	attrs.SetLoadBalancingAlgorithmType(d.Get("load_balancing_algorithm_type").(string))
 
 	containerPort := int32(d.Get("container_port").(int))
 
@@ -404,6 +418,7 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 	_ = d.Set("platform", endpoint.GetPlatform())
 	_ = d.Set("external_hostname", endpoint.GetExternalHost())
 	_ = d.Set("shared", endpoint.GetShared())
+	_ = d.Set("load_balancing_algorithm_type", endpoint.GetLoadBalancingAlgorithmType())
 
 	for _, c := range endpoint.GetAcmeConfiguration().Challenges {
 		// Skip non-DNS challenges
@@ -491,6 +506,11 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		attrs.SetShared(d.Get("shared").(bool))
 	}
 
+	if d.HasChange("load_balancing_algorithm_type") {
+		needsDeploy = true
+		attrs.SetLoadBalancingAlgorithmType(d.Get("load_balancing_algorithm_type").(string))
+	}
+
 	_, err := client.VhostsAPI.
 		UpdateVhost(ctx, endpointID).
 		UpdateVhostRequest(*attrs).
@@ -560,4 +580,10 @@ var validPlatforms = []string{
 var validResourceTypes = []string{
 	"app",
 	"database",
+}
+
+var validLbAlgorithms = []string{
+	"round_robin",
+	"least_outstanding_requests",
+	"weighted_random",
 }

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -298,6 +298,28 @@ func TestAccResourceEndpoint_sharedUpgrade(t *testing.T) {
 	})
 }
 
+func TestAccResourceEndpoint_lbAlgorithm(t *testing.T) {
+	appHandle := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAptibleEndpointLbAlgorithm(appHandle, "least_outstanding_requests"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_Type", "least_outstanding_requests"),
+				),
+			},
+			{
+				ResourceName:      "aptible_endpoint.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceEndpoint_expectError(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -319,6 +341,10 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 			{
 				Config:      testAccAptibleEndpointInvalidDomain(),
 				ExpectError: regexp.MustCompile(`(?i)managed endpoints must specify a domain`),
+			},
+			{
+				Config:      testAccAptibleEndpointInvalidLbAlgorithm(),
+				ExpectError: regexp.MustCompile(`(?i)expected load_balancing_algorithm_type to be one of .*, got should-error`),
 			},
 			{
 				Config:      testAccAptibleEndpointInvalidContainerPort(),
@@ -351,6 +377,10 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 			{
 				Config:      testAccAptibleEndpointInvalidSharedWithWildcardDomain(),
 				ExpectError: regexp.MustCompile(`(?i)cannot use domain`),
+			},
+			{
+				Config:      testAccAptibleEndpointInvalidLbAlgorithmWithElb(),
+				ExpectError: regexp.MustCompile(`(?i)do not specify a load balancing algorithm with elb endpoint`),
 			},
 		},
 	})

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -649,6 +649,43 @@ func testAccAptibleEndpointSetShared(appHandle string, shared bool) string {
 	return output
 }
 
+func testAccAptibleEndpointLbAlgorithm(appHandle string, lbAlgorithm string) string {
+	output := fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle = "%s"
+		org_id = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_app" "test" {
+		env_id = aptible_environment.test.env_id
+		handle = "%v"
+		config = {
+			"APTIBLE_DOCKER_IMAGE" = "quay.io/aptible/nginx-mirror:31"
+		}
+		service {
+			process_type = "cmd"
+			container_memory_limit = 512
+			container_count = 1
+		}
+	}
+
+	resource "aptible_endpoint" "test" {
+		env_id = aptible_environment.test.env_id
+		resource_id = aptible_app.test.app_id
+		resource_type = "app"
+		process_type = "cmd"
+		endpoint_type = "https"
+		managed = true
+		default_domain = true
+		platform = "alb"
+		load_balancing_algorithm_type: "%s"
+	}
+`, appHandle, testOrganizationId, testStackId, appHandle, lbAlgorithm)
+	log.Println("HCL generated: ", output)
+	return output
+}
+
 func testAccAptibleEndpointBadPort(appHandle string) string {
 	// Use a bad port to make the provision operation fail
 	output := fmt.Sprintf(`
@@ -738,6 +775,21 @@ func testAccAptibleEndpointInvalidDomain() string {
 		platform = "alb"
 		managed = true
 		domain = ""
+	}`
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidLbAlgorithm() string {
+	output := `
+	resource "aptible_endpoint" "test" {
+		env_id = -1
+		resource_id = 1
+		resource_type = "app"
+		process_type = "cmd"
+		default_domain = true
+		platform = "alb"
+		load_balancing_algorithm_type = "should-error"
 	}`
 	log.Println("HCL generated: ", output)
 	return output
@@ -876,6 +928,23 @@ func testAccAptibleEndpointInvalidSharedWithWildcardDomain() string {
 		managed = true
 		container_port = 3000
                 shared = true
+	}`
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidLbAlgorithmWithElb() string {
+	output := `
+	resource "aptible_endpoint" "test" {
+		env_id = -1
+		endpoint_type = "https"
+		resource_id = 1
+		resource_type = "app"
+		process_type = "cmd"
+		default_domain = true
+		platform = "elb"
+		managed = true
+		container_port = 3000
 	}`
 	log.Println("HCL generated: ", output)
 	return output

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -99,6 +99,8 @@ resource "aws_route53_record" "dns01" {
   with other apps on the same stack. Shared endpoints can only be used if your
   clients support SNI (most modern clients do) and you either use a default
   domain or an exact (non-wildcard) custom domain.
+- `load_balancing_algorithm_type` - (Optional, ALB endpoints only) Determines which algorithm to use for 
+  [request routing](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/overview#traffic). Valid options are `round_robin`, `least_outstanding_requests`, and `weighted_random`. The default is `round_robin`. 
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.1
 
 require (
-	github.com/aptible/aptible-api-go v0.9.0
+	github.com/aptible/aptible-api-go v0.10.0
 	github.com/aptible/go-deploy v0.5.4
 	github.com/bflad/tfproviderdocs v0.9.1
 	github.com/bflad/tfproviderlint v0.28.1

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/aptible/aptible-api-go v0.8.1-0.20250606132147-64f6754fd5f7 h1:bU5En2
 github.com/aptible/aptible-api-go v0.8.1-0.20250606132147-64f6754fd5f7/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/aptible-api-go v0.9.0 h1:hv0XxWA8JhtcdqP0s6mEPpifUaNzvpFtgVQdgx33n/g=
 github.com/aptible/aptible-api-go v0.9.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
+github.com/aptible/aptible-api-go v0.10.0 h1:NbMMpLUZJbLygdzJSpVDLeShFnPSIojIa9/60xxO4rc=
+github.com/aptible/aptible-api-go v0.10.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/go-deploy v0.5.4 h1:fUXkJ5kzJhl2alknsV7OndpHirLIXHd8l8Zp6bhIlL0=
 github.com/aptible/go-deploy v0.5.4/go.mod h1:h0Zt8I+pV3aqvPo+rA1hIeQjT/13RzFPYuTmg4+SyPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -109,12 +109,6 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/aptible/aptible-api-go v0.8.0 h1:0uUnVRUyihIUeHj+dGSbtngvuQ2iOuJex13Apy9kTRU=
-github.com/aptible/aptible-api-go v0.8.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
-github.com/aptible/aptible-api-go v0.8.1-0.20250606132147-64f6754fd5f7 h1:bU5En2C1i+dR00QmvIdpnhnvt9C52SmIUcvLDzp061w=
-github.com/aptible/aptible-api-go v0.8.1-0.20250606132147-64f6754fd5f7/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
-github.com/aptible/aptible-api-go v0.9.0 h1:hv0XxWA8JhtcdqP0s6mEPpifUaNzvpFtgVQdgx33n/g=
-github.com/aptible/aptible-api-go v0.9.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/aptible-api-go v0.10.0 h1:NbMMpLUZJbLygdzJSpVDLeShFnPSIojIa9/60xxO4rc=
 github.com/aptible/aptible-api-go v0.10.0/go.mod h1:JIQ26rTFdhNrST98Ji1TI9OMd0/YqqxIkmiZld2YN7s=
 github.com/aptible/go-deploy v0.5.4 h1:fUXkJ5kzJhl2alknsV7OndpHirLIXHd8l8Zp6bhIlL0=


### PR DESCRIPTION
Adds the load_balancing_algorithm_type as an optional field for ALB endpoints.

tested:
- Creating an ALB w/ LOR (good)
- Creating an ELB w/ LOR (didn't work - good)
- Creating a database endpoint w/ LOR (didn't work - good)
- Modifying an existing ALB w/ a different alg (good) 