### PR TITLE
Fix load_balancing_algorithm_type defaulting + tesets

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -582,7 +582,6 @@ var validResourceTypes = []string{
 }
 
 var validLbAlgorithms = []string{
-	"",
 	"round_robin",
 	"least_outstanding_requests",
 	"weighted_random",

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -131,12 +131,9 @@ func resourceEndpoint() *schema.Resource {
 				Default:  false,
 			},
 			"load_balancing_algorithm_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.Any(
-					validation.StringIsEmpty,
-					validation.StringInSlice(validLbAlgorithms, false),
-				),
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(validLbAlgorithms, false),
 			},
 		},
 	}
@@ -585,6 +582,7 @@ var validResourceTypes = []string{
 }
 
 var validLbAlgorithms = []string{
+	"",
 	"round_robin",
 	"least_outstanding_requests",
 	"weighted_random",

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -134,6 +134,7 @@ func resourceEndpoint() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(validLbAlgorithms, false),
+				Default:      nil,
 			},
 		},
 	}

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -131,9 +131,12 @@ func resourceEndpoint() *schema.Resource {
 				Default:  false,
 			},
 			"load_balancing_algorithm_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(validLbAlgorithms, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.Any(
+					validation.StringIsEmpty,
+					validation.StringInSlice(validLbAlgorithms, false),
+				),
 			},
 		},
 	}

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -134,7 +134,6 @@ func resourceEndpoint() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(validLbAlgorithms, false),
-				Default:      nil,
 			},
 		},
 	}
@@ -165,7 +164,7 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 	}
 
 	// load balancing algorithm can only be used with ALBs
-	if (lbAlgorithmType != "round_robin") && (platform != "alb") {
+	if (lbAlgorithmType != "") && (platform != "alb") {
 		err = multierror.Append(err, fmt.Errorf("do not specify a load balancing algorithm with %s endpoint", platform))
 	}
 
@@ -284,7 +283,10 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 	attrs.SetDefault(defaultDomain)
 	attrs.SetAcme(managed)
 	attrs.SetShared(shared)
-	attrs.SetLoadBalancingAlgorithmType(d.Get("load_balancing_algorithm_type").(string))
+	lbAlgorithmType := d.Get("load_balancing_algorithm_type").(string)
+	if lbAlgorithmType != "" {
+		attrs.SetLoadBalancingAlgorithmType(lbAlgorithmType)
+	}
 
 	containerPort := int32(d.Get("container_port").(int))
 
@@ -508,7 +510,10 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if d.HasChange("load_balancing_algorithm_type") {
 		needsDeploy = true
-		attrs.SetLoadBalancingAlgorithmType(d.Get("load_balancing_algorithm_type").(string))
+		lbAlgorithmType := d.Get("load_balancing_algorithm_type").(string)
+		if lbAlgorithmType != "" {
+			attrs.SetLoadBalancingAlgorithmType(lbAlgorithmType)
+		}
 	}
 
 	_, err := client.VhostsAPI.

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -973,6 +973,7 @@ func testAccAptibleEndpointInvalidLbAlgorithmWithElb() string {
 		process_type = "cmd"
 		default_domain = true
 		platform = "elb"
+		load_balancing_algorithm_type = "round_robin"
 	}`
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -974,7 +974,6 @@ func testAccAptibleEndpointInvalidLbAlgorithmWithElb() string {
 		process_type = "cmd"
 		default_domain = true
 		platform = "elb"
-		managed = true
 	}`
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -709,7 +709,7 @@ func testAccAptibleEndpointLbAlgorithm(appHandle string, lbAlgorithm string) str
 		managed = true
 		default_domain = true
 		platform = "alb"
-		load_balancing_algorithm_type: "%s"
+		load_balancing_algorithm_type = "%s"
 	}
 `, appHandle, testOrganizationId, testStackId, appHandle, lbAlgorithm)
 	log.Println("HCL generated: ", output)

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -308,7 +308,7 @@ func TestAccResourceEndpoint_lbAlgorithm(t *testing.T) {
 			{
 				Config: testAccAptibleEndpointLbAlgorithm(appHandle, "least_outstanding_requests"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_Type", "least_outstanding_requests"),
+					resource.TestCheckResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
 				),
 			},
 			{

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -154,7 +154,6 @@ func TestAccResourceEndpoint_appContainerPorts(t *testing.T) {
 					resource.TestMatchResourceAttr("aptible_endpoint.test", "external_hostname", regexp.MustCompile(`elb.*`)),
 					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "dns_validation_record"),
 					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "dns_validation_value"),
-					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_type"),
 				),
 			},
 			{

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -189,7 +189,6 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "false"),
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "platform", "elb"),
 						resource.TestCheckResourceAttrSet("aptible_endpoint.test", "endpoint_id"),
-						resource.TestCheckNoResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_type"),
 					),
 				},
 				{

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -975,7 +975,6 @@ func testAccAptibleEndpointInvalidLbAlgorithmWithElb() string {
 		default_domain = true
 		platform = "elb"
 		managed = true
-		container_port = 3000
 	}`
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -154,6 +154,7 @@ func TestAccResourceEndpoint_appContainerPorts(t *testing.T) {
 					resource.TestMatchResourceAttr("aptible_endpoint.test", "external_hostname", regexp.MustCompile(`elb.*`)),
 					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "dns_validation_record"),
 					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "dns_validation_value"),
+					resource.TestCheckNoResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_type"),
 				),
 			},
 			{
@@ -188,6 +189,7 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "false"),
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "platform", "elb"),
 						resource.TestCheckResourceAttrSet("aptible_endpoint.test", "endpoint_id"),
+						resource.TestCheckNoResourceAttr("aptible_endpoint.test", "load_balancing_algorithm_type"),
 					),
 				},
 				{
@@ -706,7 +708,6 @@ func testAccAptibleEndpointLbAlgorithm(appHandle string, lbAlgorithm string) str
 		resource_type = "app"
 		process_type = "cmd"
 		endpoint_type = "https"
-		managed = true
 		default_domain = true
 		platform = "alb"
 		load_balancing_algorithm_type = "%s"


### PR DESCRIPTION
Default null when empty string is returned. 

Don't pass load_balancing_algorithm_type unless it changed.

Fix typo

Fix tests

<img width="901" height="184" alt="Screenshot 2025-07-18 at 2 46 58 PM" src="https://github.com/user-attachments/assets/b0b5ce03-4b51-42f0-9a01-ee1ab4099363" />
