### PR TITLE
feat: allow simple instance family selection rather than forcing instance classes

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -83,8 +83,9 @@ func resourceService() *schema.Resource {
 			"container_profile": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "m5",
+				Default:      "m",
 				ValidateFunc: validateContainerProfile,
+				StateFunc:    normalizeContainerProfile,
 			},
 			"force_zero_downtime": {
 				Type:     schema.TypeBool,
@@ -401,7 +402,7 @@ func resourceAppRead(ctx context.Context, d *schema.ResourceData, meta interface
 		if s.ContainerMemoryLimitMb.IsSet() {
 			service["container_memory_limit"] = *s.ContainerMemoryLimitMb.Get()
 		}
-		service["container_profile"] = s.InstanceClass
+		service["container_profile"] = normalizeContainerProfile(s.InstanceClass)
 		service["process_type"] = s.ProcessType
 		log.Printf("ZDD flags: %t, %t", s.ForceZeroDowntime, s.NaiveHealthCheck)
 		service["force_zero_downtime"] = s.ForceZeroDowntime

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -624,7 +624,7 @@ func testAccAptibleAppDeploy(handle string, index string) string {
 		}
     service {
 			process_type = "cmd"
-			container_profile = "m5"
+			container_profile = "m"
 			container_memory_limit = 512
 			container_count = 1
 			force_zero_downtime = true
@@ -653,7 +653,7 @@ func testAccAptibleAppDeployStopTimeout(handle string, index string) string {
 		}
     service {
 			process_type = "cmd"
-			container_profile = "m5"
+			container_profile = "m"
 			container_memory_limit = 512
 			container_count = 1
 			force_zero_downtime = true
@@ -682,13 +682,13 @@ func testAccAptibleAppDeployMultipleServices(handle string) string {
 		}
 		service {
 			process_type = "main"
-			container_profile = "m5"
+			container_profile = "m"
 			container_memory_limit = 512
 			container_count = 1
 		}
 		service {
 			process_type = "cron"
-			container_profile = "r5"
+			container_profile = "r"
 			container_memory_limit = 512
 			container_count = 1
 		}
@@ -763,7 +763,7 @@ func testAccAptibleAppautoscalingPolicy(handle string, index string) string {
 		}
 		service {
 			process_type           = "cmd"
-			container_profile      = "m5"
+			container_profile      = "m"
 			container_count        = 1
 			autoscaling_policy {
 				autoscaling_type  = "horizontal"
@@ -794,7 +794,7 @@ func testAccAptibleAppWithoutautoscalingPolicy(handle string) string {
 		}
 		service {
 			process_type           = "cmd"
-			container_profile      = "m5"
+			container_profile      = "m"
 			container_count        = 1
 		}
 	}
@@ -818,7 +818,7 @@ func testAccAptibleAppUpdateautoscalingPolicy(handle string) string {
 		}
 		service {
 			process_type           = "cmd"
-			container_profile      = "m5"
+			container_profile      = "m"
 			container_memory_limit = 512
 			container_count        = 1
 			autoscaling_policy {
@@ -874,7 +874,7 @@ func testAccAptibleAppDeployAutoscalingOldAndNewPolicyAttribute(handle string) s
 		}
 		service {
 			process_type           = "cmd"
-			container_profile      = "m5"
+			container_profile      = "m"
 			container_memory_limit = 512
 			container_count        = 1
 			autoscaling_policy {
@@ -995,7 +995,7 @@ func testAccAptibleAppDeployWithRestartFreeScaling(handle string, restartFreeSca
 		}
 		service {
 			process_type = "cmd"
-			container_profile = "m5"
+			container_profile = "m"
 			container_memory_limit = 512
 			container_count = 1
 			restart_free_scaling = %t

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -52,7 +52,8 @@ func resourceDatabase() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateContainerProfile,
-				Default:      "m5",
+				StateFunc:    normalizeContainerProfile,
+				Default:      "m",
 			},
 			"disk_size": {
 				Type:         schema.TypeInt,
@@ -243,7 +244,7 @@ func resourceDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	profile := service.GetInstanceClass()
 
 	_ = d.Set("container_size", containerSize)
-	_ = d.Set("container_profile", profile)
+	_ = d.Set("container_profile", normalizeContainerProfile(profile))
 	_ = d.Set("iops", database.Embedded.Disk.GetProvisionedIops())
 	_ = d.Set("disk_size", database.Embedded.Disk.GetSize())
 	_ = d.Set("default_connection_url", database.GetConnectionUrl())

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -33,7 +33,7 @@ func TestAccResourceDatabase_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
 						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
-						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_database.test", "iops", "3000"),
 						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
 						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
@@ -71,7 +71,7 @@ func TestAccResourceDatabase_withoutBackups(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
 						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
-						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_database.test", "iops", "3000"),
 						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
 						// TEMPORARILY DISABLED - PITR must be disabled before backups can be disabled
@@ -109,7 +109,7 @@ func TestAccResourceDatabase_redis(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "redis"),
 						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
 						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
-						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_database.test", "iops", "3000"),
 						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
 						resource.TestCheckResourceAttrSet("aptible_database.test", "database_image_id"),
@@ -148,7 +148,7 @@ func TestAccResourceDatabase_version(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
 						resource.TestCheckResourceAttr("aptible_database.test", "version", "9.4"),
 						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
-						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_database.test", "iops", "3000"),
 						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
 						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
@@ -183,7 +183,7 @@ func TestAccResourceDatabase_update(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
 						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
 						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "10"),
-						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_database.test", "iops", "3000"),
 						resource.TestCheckResourceAttr("aptible_database.test", "enable_backups", "true"),
 						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
@@ -201,7 +201,7 @@ func TestAccResourceDatabase_update(t *testing.T) {
 				// 	Config: testAccAptibleDatabaseUpdate(env.ID, dbHandle),
 				// 	Check: resource.ComposeTestCheckFunc(
 				// 		resource.TestCheckResourceAttr("aptible_database.test", "container_size", "512"),
-				// 		resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "r5"),
+				// 		resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "r"),
 				// 		resource.TestCheckResourceAttr("aptible_database.test", "iops", "4000"),
 				// 		resource.TestCheckResourceAttr("aptible_database.test", "enable_backups", "false"),
 				// 		resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "20"),
@@ -257,7 +257,7 @@ func TestAccResourceDatabase_scale(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_database.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_database.test", "database_type", "postgresql"),
 						resource.TestCheckResourceAttr("aptible_database.test", "container_size", "1024"),
-						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "r5"),
+						resource.TestCheckResourceAttr("aptible_database.test", "container_profile", "r"),
 						resource.TestCheckResourceAttr("aptible_database.test", "iops", "4000"),
 						resource.TestCheckResourceAttr("aptible_database.test", "disk_size", "12"),
 						resource.TestCheckResourceAttrSet("aptible_database.test", "database_id"),
@@ -331,7 +331,7 @@ func testAccAptibleDatabaseRedis(envId int64, dbHandle string) string {
 		env_id = %d
 		handle = "%v"
 		database_type = "redis"
-		container_profile = "m5"
+		container_profile = "m"
 	}
 `, envId, dbHandle)
 }
@@ -355,7 +355,7 @@ func testAccAptibleDatabaseUpdate(envId int64, dbHandle string) string {
 		handle = "%v"
 		container_size = %d
 		disk_size = %d
-		container_profile = "r5"
+		container_profile = "r"
 		iops = 4000
 		enable_backups = false
 	}
@@ -397,7 +397,7 @@ func testAccAptibleDatabaseScale(envId int64, dbHandle string) string {
 	resource "aptible_database" "test" {
 		env_id = %d
 		handle = "%v"
-		container_profile = "r5"
+		container_profile = "r"
 		iops = 4000
 		disk_size = 12
 	}

--- a/aptible/resource_replica.go
+++ b/aptible/resource_replica.go
@@ -56,7 +56,8 @@ func resourceReplica() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateContainerProfile,
-				Default:      "m5",
+				StateFunc:    normalizeContainerProfile,
+				Default:      "m",
 			},
 			"iops": {
 				Type:     schema.TypeInt,
@@ -261,7 +262,7 @@ func resourceReplicaRead(d *schema.ResourceData, meta interface{}) error {
 	_ = d.Set("handle", database.GetHandle())
 	_ = d.Set("env_id", accountID)
 	_ = d.Set("primary_database_id", primaryDatabaseID)
-	_ = d.Set("container_profile", profile)
+	_ = d.Set("container_profile", normalizeContainerProfile(profile))
 	_ = d.Set("iops", database.Embedded.Disk.GetProvisionedIops())
 	_ = d.Set("enable_backups", database.GetEnableBackups())
 	d.SetId(strconv.Itoa(int(database.Id)))

--- a/aptible/resource_replica_test.go
+++ b/aptible/resource_replica_test.go
@@ -38,7 +38,7 @@ func TestAccResourceReplica_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "iops", "3000"),
-						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
 						resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
 						resource.TestCheckResourceAttrSet("aptible_replica.test", "default_connection_url"),
@@ -79,7 +79,7 @@ func TestAccResourceReplica_withoutBackups(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "iops", "3000"),
-						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
 						// TEMPORARILY DISABLED - PITR must be disabled before backups can be disabled
 						// resource.TestCheckResourceAttr("aptible_replica.test", "enable_backups", "false"),
@@ -122,7 +122,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_replica.test", "handle", replicaHandle),
 						resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
-						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "m5"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "m"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "iops", "3000"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "10"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "enable_backups", "true"),
@@ -139,7 +139,7 @@ func TestAccResourceReplica_update(t *testing.T) {
 				// {
 				// 	Config: testAccAptibleReplicaUpdate(env.ID, dbHandle, replicaHandle),
 				// 	Check: resource.ComposeTestCheckFunc(
-				// 		resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "r5"),
+				// 		resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "r"),
 				// 		resource.TestCheckResourceAttr("aptible_replica.test", "iops", "4000"),
 				// 		resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "512"),
 				// 		resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "20"),
@@ -241,7 +241,7 @@ func TestAccResourceReplica_scale(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_replica.test", "env_id", strconv.Itoa(int(env.ID))),
 						resource.TestCheckResourceAttr("aptible_replica.test", "container_size", "1024"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "iops", "4000"),
-						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "r5"),
+						resource.TestCheckResourceAttr("aptible_replica.test", "container_profile", "r"),
 						resource.TestCheckResourceAttr("aptible_replica.test", "disk_size", "12"),
 						resource.TestCheckResourceAttrSet("aptible_replica.test", "replica_id"),
 						resource.TestCheckResourceAttrSet("aptible_replica.test", "default_connection_url"),
@@ -302,7 +302,7 @@ func testAccAptibleReplicaUpdate(envId int64, dbHandle string, repHandle string)
 		primary_database_id = aptible_database.test.database_id
 		container_size = %d
 		disk_size = %d
-		container_profile = "r5"
+		container_profile = "r"
 		iops = 4000
 		enable_backups = false
 	}
@@ -342,7 +342,7 @@ func testAccAptibleReplicaScale(envId int64, dbHandle string, replicaHandle stri
 		env_id = %d
 		handle = "%v"
 		primary_database_id = aptible_database.test.database_id
-		container_profile = "r5"
+		container_profile = "r"
 		iops = 4000
 		disk_size = 12
 	}

--- a/aptible/validation.go
+++ b/aptible/validation.go
@@ -3,6 +3,7 @@ package aptible
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -72,11 +73,18 @@ var validContainerSizes = []int{
 var validateContainerSize = validation.IntInSlice(validContainerSizes)
 
 var validContainerProfiles = []string{
-	"m4",
-	"m5",
-	"r5",
-	"c5",
+	"m",
+	"c",
+	"r",
 }
-var validateContainerProfile = errorsToWarnings(validation.StringInSlice(validContainerProfiles, false))
+var validateContainerProfile = validation.StringInSlice(validContainerProfiles, false)
+
+// normalizeContainerProfile strips trailing generation digits from an instance
+// class name (e.g. "m5" → "m", "c6" → "c"). The backend may still return
+// old-style values; normalizing them prevents spurious state diffs.
+// Satisfies schema.SchemaStateFunc so it can be used directly as StateFunc.
+func normalizeContainerProfile(v interface{}) string {
+	return strings.TrimRight(v.(string), "0123456789")
+}
 
 var validateDiskSize = validation.IntBetween(1, 16000)

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -70,11 +70,11 @@ The `service` block supports:
   service.
 - `container_memory_limit` - (Default: 1024) The memory limit (in MB) of the
   service's containers.
-- `container_profile` - (Default: `m5`) Changes the CPU:RAM ratio of the
+- `container_profile` - (Default: `m`) Changes the CPU:RAM ratio of the
   service's containers.
-  - `m4` - General Purpose (1 CPU : 4 GB RAM)
-  - `c5` - CPU Optimized (1 CPU : 2 GB RAM)
-  - `r5` - Memory Optimized (1 CPU : 8 GB RAM)
+  - `m` - General Purpose (1 CPU : 4 GB RAM)
+  - `c` - CPU Optimized (1 CPU : 2 GB RAM)
+  - `r` - Memory Optimized (1 CPU : 8 GB RAM)
 - `force_zero_downtime` - (Default: false) For services without endpoints, force
   a zero-downtime release and leverage docker healthchecks for the containers. Please
   note that docker healthchecks are required unless `simple_health_check` is enabled.

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -35,11 +35,11 @@ resource "aptible_database" "example_database" {
   this defaults to the latest recommended version.
 - `container_size` - (Default: 1024) The size of container used for the
   Database, in MB of RAM.
-- `container_profile` - (Default: `m5`) Changes the CPU:RAM ratio of the
+- `container_profile` - (Default: `m`) Changes the CPU:RAM ratio of the
   Database container.
-  - `m5` - General Purpose (1 CPU : 4 GB RAM)
-  - `c5` - CPU Optimized (1 CPU : 2 GB RAM)
-  - `r5` - Memory Optimized (1 CPU : 8 GB RAM)
+  - `m` - General Purpose (1 CPU : 4 GB RAM)
+  - `c` - CPU Optimized (1 CPU : 2 GB RAM)
+  - `r` - Memory Optimized (1 CPU : 8 GB RAM)
 - `disk_size` - The disk size of the Database, in GB.
 - `iops` - The disk Input/Output Operations Per Second
 - `enable_backups` - (Default: `true`) Whether to automatically backup the database according to the retention policy.

--- a/docs/resources/replica.md
+++ b/docs/resources/replica.md
@@ -33,11 +33,11 @@ resource "aptible_replica" "example_database_replica" {
   only contain letters, numbers, `-`, `_`, or `.`
 - `container_size` - (Default: 1024) The size of container used for the
   Database, in MB of RAM.
-- `container_profile` - (Default: `m5`) Changes the CPU:RAM ratio of the
+- `container_profile` - (Default: `m`) Changes the CPU:RAM ratio of the
   Database container.
-  - `m5` - General Purpose (1 CPU : 4 GB RAM)
-  - `c5` - CPU Optimized (1 CPU : 2 GB RAM)
-  - `r5` - Memory Optimized (1 CPU : 8 GB RAM)
+  - `m` - General Purpose (1 CPU : 4 GB RAM)
+  - `c` - CPU Optimized (1 CPU : 2 GB RAM)
+  - `r` - Memory Optimized (1 CPU : 8 GB RAM)
 - `disk_size` - The disk size of the Database, in GB.
 - `iops` - The disk Input/Output Operations Per Second
 - `enable_backups` - (Default: `true`) Whether to automatically backup the database according to the retention policy.


### PR DESCRIPTION
Content pending verification with integration test suite.

The purpose of this pull request is to simplify profile selection matching what we currently list for pricing. The options should be listed as `m`, `c` and/or `r` (which matches what options are selectable on the pricing page - https://www.aptible.com/pricing and [other documentation](https://www.aptible.com/docs/core-concepts/scaling/container-profiles)).  This will enforce a validation error if other options are selected.

---

Verified passage of branch

<img width="671" height="72" alt="image" src="https://github.com/user-attachments/assets/da0798ca-25c8-493b-a9f8-1440ab263987" />
