### PR TITLE
Handle backend-managed platform for database endpoints

### DIFF
--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -104,6 +104,10 @@ func resourceEndpoint() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(validPlatforms, false),
 				Default:      "alb",
+				DiffSuppressFunc: func(_ string, _, _ string, d *schema.ResourceData) bool {
+					// Database endpoint platform is backend-managed.
+					return d.Get("resource_type").(string) == "database"
+				},
 			},
 			"endpoint_id": {
 				Type:     schema.TypeInt,
@@ -145,6 +149,7 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 	containerPorts, _ := aptible.MakeInt64Slice(interfaceContainerPortsSlice)
 	containerPort, _ := (d.Get("container_port").(int))
 	endpointType := d.Get("endpoint_type").(string)
+	resourceType := d.Get("resource_type").(string)
 	platform := d.Get("platform").(string)
 	lbAlgorithmType := d.Get("load_balancing_algorithm_type").(string)
 	var err error
@@ -161,6 +166,10 @@ func resourceEndpointValidate(_ context.Context, diff *schema.ResourceDiff, _ in
 	// container ports can only be used with tls/tcp
 	if len(containerPorts) != 0 && (endpointType == "https" || endpointType == "grpc") {
 		err = multierror.Append(err, fmt.Errorf("do not specify container ports with %s endpoint (see terraform docs)", endpointType))
+	}
+
+	if resourceType == "app" && platform == "nlb" {
+		err = multierror.Append(err, fmt.Errorf("platform 'nlb' is not supported for app endpoints"))
 	}
 
 	// load balancing algorithm can only be used with ALBs
@@ -279,7 +288,9 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 	attrs := aptibleapi.NewCreateVhostRequest(endpointType)
 	attrs.SetInternal(d.Get("internal").(bool))
 	attrs.SetIpWhitelist(ipWhitelist)
-	attrs.SetPlatform(d.Get("platform").(string))
+	if resourceType != "database" {
+		attrs.SetPlatform(d.Get("platform").(string))
+	}
 	attrs.SetDefault(defaultDomain)
 	attrs.SetAcme(managed)
 	attrs.SetShared(shared)
@@ -580,6 +591,7 @@ var validEndpointTypes = []string{
 var validPlatforms = []string{
 	"alb",
 	"elb",
+	"nlb",
 }
 
 var validResourceTypes = []string{

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -191,6 +191,13 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 					),
 				},
 				{
+					// Re-plan with the same config to confirm DiffSuppress hides any
+					// platform drift the backend may report for database endpoints.
+					Config:             testAccAptibleEndpointDatabase(env.ID, dbHandle),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: false,
+				},
+				{
 					ResourceName:      "aptible_endpoint.test",
 					ImportState:       true,
 					ImportStateVerify: true,

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -186,7 +186,7 @@ func TestAccResourceEndpoint_db(t *testing.T) {
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "resource_type", "database"),
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "endpoint_type", "tcp"),
 						resource.TestCheckResourceAttr("aptible_endpoint.test", "internal", "false"),
-						resource.TestCheckResourceAttr("aptible_endpoint.test", "platform", "elb"),
+						resource.TestMatchResourceAttr("aptible_endpoint.test", "platform", regexp.MustCompile(`^(elb|nlb)$`)),
 						resource.TestCheckResourceAttrSet("aptible_endpoint.test", "endpoint_id"),
 					),
 				},
@@ -381,6 +381,10 @@ func TestAccResourceEndpoint_expectError(t *testing.T) {
 			{
 				Config:      testAccAptibleEndpointInvalidLbAlgorithmWithElb(),
 				ExpectError: regexp.MustCompile(`(?i)do not specify a load balancing algorithm with elb endpoint`),
+			},
+			{
+				Config:      testAccAptibleEndpointInvalidAppNlbPlatform(),
+				ExpectError: regexp.MustCompile(`(?i)platform 'nlb' is not supported for app endpoints`),
 			},
 		},
 	})
@@ -597,7 +601,6 @@ func testAccAptibleEndpointDatabase(envId int64, dbHandle string) string {
 		resource_type = "database"
 		endpoint_type = "tcp"
 		internal = false
-		platform = "elb"
 	}
 `, envId, dbHandle, envId)
 	log.Println("HCL generated: ", output)
@@ -973,6 +976,20 @@ func testAccAptibleEndpointInvalidLbAlgorithmWithElb() string {
 		default_domain = true
 		platform = "elb"
 		load_balancing_algorithm_type = "round_robin"
+	}`
+	log.Println("HCL generated: ", output)
+	return output
+}
+
+func testAccAptibleEndpointInvalidAppNlbPlatform() string {
+	output := `
+	resource "aptible_endpoint" "test" {
+		env_id = -1
+		endpoint_type = "tcp"
+		resource_id = 1
+		resource_type = "app"
+		process_type = "cmd"
+		platform = "nlb"
 	}`
 	log.Println("HCL generated: ", output)
 	return output

--- a/aptible/resource_endpoint_unit_test.go
+++ b/aptible/resource_endpoint_unit_test.go
@@ -1,0 +1,49 @@
+package aptible
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestResourceEndpointPlatformDiffSuppress(t *testing.T) {
+	platformSchema := resourceEndpoint().Schema["platform"]
+
+	tests := []struct {
+		name         string
+		resourceType string
+		oldValue     string
+		newValue     string
+		want         bool
+	}{
+		{
+			name:         "suppresses database platform drift",
+			resourceType: "database",
+			oldValue:     "elb",
+			newValue:     "nlb",
+			want:         true,
+		},
+		{
+			name:         "does not suppress app platform drift",
+			resourceType: "app",
+			oldValue:     "elb",
+			newValue:     "nlb",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceEndpoint().Schema, map[string]interface{}{
+				"env_id":        1,
+				"resource_id":   1,
+				"resource_type": tt.resourceType,
+			})
+
+			got := platformSchema.DiffSuppressFunc("platform", tt.oldValue, tt.newValue, d)
+			if got != tt.want {
+				t.Fatalf("DiffSuppressFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -87,10 +87,12 @@ resource "aws_route53_record" "dns01" {
 - `internal` - (Default: false) If Endpoint should be available
   [internally or externally](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/overview#endpoint-placement)
   . Changing this will force the resource to be recreated.
-- `platform` - (Default: `alb`) What type of
+- `platform` - (App only, Default: `alb`) What type of
   [load balancer](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/https-endpoints/alb-elb)
-  the Endpoint should use. Valid options are `alb` or `elb`. `resource_type` of
-  `database` should use `elb`.
+  the Endpoint should use. Valid options for app endpoints are `alb` or `elb`.
+  `nlb` is not supported for app endpoints in this provider release.
+- Database endpoints do not require `platform`. Aptible manages the database
+  endpoint platform, so any configured value is ignored.
 - `ip_filtering` - (Optional) The list of IPv4 CIDRs that the Endpoint will
   allow traffic from. If not provided, the Endpoint will not filter traffic. See
   the [IP Filtering](https://www.aptible.com/docs/core-concepts/apps/connecting-to-apps/app-endpoints/ip-filtering)

--- a/examples/nginx.tf
+++ b/examples/nginx.tf
@@ -43,5 +43,5 @@ resource "aptible_endpoint" "https" {
   endpoint_type  = "https" // other options: tcp, tls
   internal       = true    // or false for external
   container_port = 80      // port #
-  platform       = "alb"   // or "elb"
+  platform       = "alb"   // app endpoints support "alb"; omit for databases
 }


### PR DESCRIPTION
## Summary

This change makes the Terraform provider tolerate the in-flight Database Vhost `elb` -> `nlb` backend migration and the upcoming deploy-api default of `platform = "nlb"` for new database endpoints.

Functionally, the goal is to prevent noisy/unfixable Terraform drift for database endpoints during that rollout. After this lands, DB endpoint platform is effectively treated as backend-managed in the provider, so existing migrated endpoints and newly created DB endpoints continue to plan cleanly as deploy-api shifts to NLB.

## Reviewer context

Today, the provider/docs still point database endpoints at `elb`, but backend state is moving toward `nlb`. That creates a bad Terraform experience: `plan` detects platform drift, while `apply` does not reconcile it.

This PR resolves that mismatch for database endpoints only, while keeping app endpoint behavior unchanged for now.

## Test plan

- Verified provider behavior for database endpoint platform drift suppression
- Updated endpoint tests/docs to match DB migration behavior
- Confirmed app endpoints still reject `platform = "nlb"` in this release

[sc-37325]
