### PR TITLE
Add deploy_trigger field to aptible_app to force a deploy without changing docker_image

### DIFF
--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -70,6 +70,16 @@ func resourceApp() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 			},
+			  "deploy_trigger": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "Arbitrary value that, when changed, forces a deploy " +
+					"(a re-pull of the current docker_image tag) without changing " +
+					"docker_image itself. Useful for redeploying a mutable tag whose " +
+					"digest has updated. The value is used only for change detection; it " +
+					"is not sent in the deploy command and does not affect which image is pulled.",
+			},
+
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 			if err := validateServiceSizingPolicy(ctx, d, meta); err != nil {
@@ -627,6 +637,13 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		settingsMap["APTIBLE_DOCKER_IMAGE"] = d.Get("docker_image").(string)
 	}
 
+	if d.HasChange("deploy_trigger") {
+		needsDeploy = true
+		settingsMap["APTIBLE_DOCKER_IMAGE"] = d.Get("docker_image").(string)
+
+	}
+
+
 	if d.HasChanges("private_registry_username", "private_registry_password") {
 		needsDeploy = true
 		sensitiveSettingsMap["APTIBLE_PRIVATE_REGISTRY_USERNAME"] = d.Get("private_registry_username").(string)
@@ -635,6 +652,10 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if needsDeploy {
 		operationType = "deploy"
+		// Always re-pull/set the current image/tag,
+		if v := d.Get("docker_image").(string); v != "" {
+				settingsMap["APTIBLE_DOCKER_IMAGE"] = v
+		}
 	} else if needsConfigure {
 		operationType = "configure"
 	}
@@ -645,8 +666,8 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		if d.HasChange("config") {
 			payload.SetEnv(envMap)
 		}
-		if d.HasChange("docker_image") {
-			payload.SetSettings(settingsMap)
+		if d.HasChanges("docker_image", "deploy_trigger") {
+				payload.SetSettings(settingsMap)
 		}
 		if d.HasChanges("private_registry_username", "private_registry_password") {
 			payload.SetSensitiveSettings(sensitiveSettingsMap)


### PR DESCRIPTION
Currently a deploy only runs when docker_image (or registry credentials) changes, so there's no way to redeploy a mutable tag like :dev when its underlying digest changes.  This adds an optional deploy_trigger field whose value, when changed, forces a deploy that re-pulls the current docker_image tag. The value is used only for change detection and isn't sent in the deploy command.