### PR TITLE
Add configuration for timeouts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,10 @@ run:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - govet
 
 linters:
   default: none

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,6 @@ lint:
 tools:
 	@go mod vendor
 	@go install github.com/bflad/tfproviderlint/cmd/tfproviderlint
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.6.2
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.11.4
 
 .PHONY: build gen test testacc fmt fmtcheck lint tools local-install

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/aptible/aptible-api-go/aptibleapi"
 	"github.com/aptible/go-deploy/aptible"
@@ -18,12 +19,17 @@ import (
 
 func resourceApp() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppCreate, // POST
-		ReadContext:   resourceAppRead,   // GET
-		UpdateContext: resourceAppUpdate, // PUT
-		Delete:        resourceAppDelete, // DELETE
+		CreateContext: resourceAppCreate,        // POST
+		ReadContext:   resourceAppRead,          // GET
+		UpdateContext: resourceAppUpdate,        // PUT
+		DeleteContext: resourceAppDeleteContext, // DELETE
 		Importer: &schema.ResourceImporter{
 			State: resourceAppImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -429,7 +435,9 @@ func resourceAppCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 			})
 		}
 
-		_, err = legacy.WaitForOperation(int64(operation.Id))
+		createCtx, createCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+		defer createCancel()
+		_, err = waitForOperationWithContext(createCtx, legacy, int64(operation.Id))
 		if err != nil {
 			// Do not return here so that the read method can hydrate the state
 			diags = append(diags, diag.Diagnostic{
@@ -481,14 +489,14 @@ func resourceAppRead(ctx context.Context, d *schema.ResourceData, meta interface
 	log.Println("Getting App with ID: " + strconv.Itoa(int(appID)))
 
 	app, resp, err := client.AppsAPI.GetApp(ctx, appID).Execute()
+	if err != nil {
+		log.Println(err)
+		return diag.FromErr(err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		log.Println("App with ID: " + strconv.Itoa(int(appID)) + " was deleted outside of Terraform. Now removing it from Terraform state.")
 		return nil
-	}
-	if err != nil {
-		log.Println(err)
-		return diag.FromErr(err)
 	}
 
 	_ = d.Set("app_id", int(app.Id))
@@ -663,7 +671,9 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 				Detail:   err.Error(),
 			})
 		}
-		_, err = legacy.WaitForOperation(int64(operation.Id))
+		updateCtx, updateCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+		defer updateCancel()
+		_, err = waitForOperationWithContext(updateCtx, legacy, int64(operation.Id))
 		if err != nil {
 			// Do not return here so that the read method can hydrate the state
 			diags = append(diags, diag.Diagnostic{
@@ -720,10 +730,10 @@ func resourceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
-	readDiags := resourceAppRead(context.Background(), d, meta)
+func resourceAppDeleteContext(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	readDiags := resourceAppRead(ctx, d, meta)
 	if readDiags.HasError() {
-		return diagnosticsToError(readDiags)
+		return readDiags
 	}
 
 	appID := int64(d.Get("app_id").(int))
@@ -735,7 +745,7 @@ func resourceAppDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err != nil {
 		log.Println("There was an error when completing the request to destroy the app.\n[ERROR] -", err)
-		return generateErrorFromClientError(err)
+		return diag.FromErr(generateErrorFromClientError(err))
 	}
 
 	d.SetId("")
@@ -913,7 +923,9 @@ func scaleServices(c context.Context, d *schema.ResourceData, meta interface{}) 
 				return err
 			}
 
-			_, err = legacy.WaitForOperation(int64(resp.Id))
+			scaleCtx, scaleCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+			defer scaleCancel()
+			_, err = waitForOperationWithContext(scaleCtx, legacy, int64(resp.Id))
 			return err
 		})
 	}

--- a/aptible/resource_app.go
+++ b/aptible/resource_app.go
@@ -27,9 +27,9 @@ func resourceApp() *schema.Resource {
 			State: resourceAppImport,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(90 * time.Minute),
+			Update: schema.DefaultTimeout(90 * time.Minute),
+			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/aptible/resource_app_test.go
+++ b/aptible/resource_app_test.go
@@ -1136,6 +1136,24 @@ func testAccAptibleAppMultipleServicesWithPartialAutoscaling(handle string) stri
 	`, handle, testOrganizationId, testStackId, handle)
 }
 
+func TestAccResourceApp_createTimeout(t *testing.T) {
+	rHandle := acctest.RandString(10)
+
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckAppDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccAptibleAppDeployWithCreateTimeout(rHandle, "1s"),
+					ExpectError: regexp.MustCompile(`timed out waiting for operation`),
+				},
+			},
+		})
+	})
+}
+
 func TestAccResourceApp_usernameWithoutPassword(t *testing.T) {
 	rHandle := acctest.RandString(10)
 
@@ -1188,6 +1206,25 @@ func TestAccResourceApp_registryCredsWithoutDockerImage(t *testing.T) {
 			},
 		})
 	})
+}
+
+func testAccAptibleAppDeployWithCreateTimeout(handle string, timeout string) string {
+	return fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle   = "%s"
+		org_id   = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_app" "test" {
+		env_id       = aptible_environment.test.env_id
+		handle       = "%s"
+		docker_image = "quay.io/aptible/nginx-mirror:1"
+		timeouts {
+			create = "%s"
+		}
+	}
+`, handle, testOrganizationId, testStackId, handle, timeout)
 }
 
 func testAccAptibleAppUsernameWithoutPassword(handle string) string {

--- a/aptible/resource_database.go
+++ b/aptible/resource_database.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/aptible/aptible-api-go/aptibleapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -14,15 +15,18 @@ import (
 )
 
 func resourceDatabase() *schema.Resource {
-	// Linter gets upset because of the mixed context and non-context methods
-	// lintignore:S024
 	return &schema.Resource{
-		CreateContext: resourceDatabaseCreate, // POST
-		Read:          resourceDatabaseRead,   // GET
-		UpdateContext: resourceDatabaseUpdate, // PUT
-		Delete:        resourceDatabaseDelete, // DELETE
+		CreateContext: resourceDatabaseCreate,        // POST
+		ReadContext:   resourceDatabaseReadContext,   // GET
+		UpdateContext: resourceDatabaseUpdate,        // PUT
+		DeleteContext: resourceDatabaseDeleteContext, // DELETE
 		Importer: &schema.ResourceImporter{
 			State: resourceDatabaseImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -180,7 +184,9 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 			Detail:   err.Error(),
 		})
 	} else {
-		_, err = legacy.WaitForOperation(int64(op.Id))
+		createCtx, createCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+		defer createCancel()
+		_, err = waitForOperationWithContext(createCtx, legacy, int64(op.Id))
 		if err != nil {
 			// Do not return so that the read method can hydrate the state
 			diags = append(diags, diag.Diagnostic{
@@ -191,24 +197,24 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	return append(diags, diag.FromErr(resourceDatabaseRead(d, meta))...)
+	return append(diags, resourceDatabaseReadContext(ctx, d, meta)...)
 }
 
 // syncs Terraform state with changes made via the API outside of Terraform
-func resourceDatabaseRead(d *schema.ResourceData, meta interface{}) error {
+func resourceDatabaseReadContext(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	m := meta.(*providerMetadata)
 	client := m.Client
-	ctx := m.APIContext(context.Background())
+	ctx = m.APIContext(ctx)
 	databaseID := int32(d.Get("database_id").(int))
 
 	database, resp, err := client.DatabasesAPI.GetDatabase(ctx, databaseID).Execute()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		log.Println("Database with ID: " + strconv.Itoa(int(databaseID)) + " was deleted outside of Terraform. Now removing it from Terraform state.")
 		return nil
-	}
-	if err != nil {
-		return err
 	}
 
 	urls := []string{}
@@ -219,25 +225,25 @@ func resourceDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 
 	imageID := ExtractIdFromLink(database.Links.DatabaseImage.GetHref())
 	if imageID == 0 {
-		return fmt.Errorf("Could not find database image ID")
+		return diag.FromErr(fmt.Errorf("Could not find database image ID"))
 	}
 	serviceID := ExtractIdFromLink(database.Links.Service.GetHref())
 	if serviceID == 0 {
-		return fmt.Errorf("Could not find database service ID")
+		return diag.FromErr(fmt.Errorf("Could not find database service ID"))
 	}
 	accountID := ExtractIdFromLink(database.Links.Account.GetHref())
 	if accountID == 0 {
-		return fmt.Errorf("Could not find database account ID")
+		return diag.FromErr(fmt.Errorf("Could not find database account ID"))
 	}
 
 	image, _, err := client.ImagesAPI.GetDatabaseImage(ctx, imageID).Execute()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	service, _, err := client.ServicesAPI.GetServiceWithOperationStatus(ctx, serviceID).Execute()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	containerSize := service.GetContainerMemoryLimitMb()
@@ -262,7 +268,7 @@ func resourceDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 func resourceDatabaseImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	databaseID, _ := strconv.Atoi(d.Id())
 	_ = d.Set("database_id", databaseID)
-	err := resourceDatabaseRead(d, meta)
+	err := diagnosticsToError(resourceDatabaseReadContext(context.Background(), d, meta))
 	return []*schema.ResourceData{d}, err
 }
 
@@ -349,7 +355,9 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			return diags
 		}
 
-		del, err := legacy.WaitForOperation(int64(op.Id))
+		updateCtx, updateCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+		defer updateCancel()
+		del, err := waitForOperationWithContext(updateCtx, legacy, int64(op.Id))
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -376,25 +384,17 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		log.Printf("[WARN] In order for the new database name (%s) to appear in log drain and metric drain destinations, you must restart the database.\n", handle)
 	}
 
-	if err := resourceDatabaseRead(d, meta); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "There was an error when trying to retrieve the updated state of the database.",
-			Detail:   err.Error(),
-		})
-	}
-
-	return diags
+	return append(diags, resourceDatabaseReadContext(ctx, d, meta)...)
 }
 
-func resourceDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceDatabaseDeleteContext(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*providerMetadata).LegacyClient
 	databaseID := int64(d.Get("database_id").(int))
 
 	err := client.DeleteDatabase(databaseID)
 	if err != nil {
 		log.Println(err)
-		return generateErrorFromClientError(err)
+		return diag.FromErr(generateErrorFromClientError(err))
 	}
 
 	d.SetId("")

--- a/aptible/resource_database_test.go
+++ b/aptible/resource_database_test.go
@@ -237,6 +237,24 @@ func TestAccResourceDatabase_update(t *testing.T) {
 	})
 }
 
+func TestAccResourceDatabase_createTimeout(t *testing.T) {
+	dbHandle := acctest.RandString(10)
+
+	WithTestAccEnvironment(t, func(env aptible.Environment) {
+		resource.ParallelTest(t, resource.TestCase{
+			PreCheck:     func() { testAccPreCheck(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckDatabaseDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config:      testAccAptibleDatabaseWithCreateTimeout(env.ID, dbHandle, "1s"),
+					ExpectError: regexp.MustCompile(`timed out waiting for operation`),
+				},
+			},
+		})
+	})
+}
+
 func TestAccResourceDatabase_expectError(t *testing.T) {
 	dbHandle := acctest.RandString(10)
 
@@ -334,6 +352,18 @@ func testAccCheckDatabaseDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func testAccAptibleDatabaseWithCreateTimeout(envId int64, dbHandle string, timeout string) string {
+	return fmt.Sprintf(`
+	resource "aptible_database" "test" {
+		env_id = %d
+		handle = "%s"
+		timeouts {
+			create = "%s"
+		}
+	}
+`, envId, dbHandle, timeout)
 }
 
 func testAccAptibleDatabaseBasic(envId int64, dbHandle string) string {

--- a/aptible/resource_endpoint.go
+++ b/aptible/resource_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aptible/aptible-api-go/aptibleapi"
 	"github.com/aptible/go-deploy/aptible"
@@ -26,6 +27,11 @@ func resourceEndpoint() *schema.Resource {
 		CustomizeDiff: resourceEndpointValidate,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceEndpointImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -526,7 +532,9 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 	_ = d.Set("endpoint_id", endpoint.Id)
 	d.SetId(strconv.Itoa(int(endpoint.Id)))
 
-	_, err = legacy.WaitForOperation(int64(operation.Id))
+	createCtx, createCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+	defer createCancel()
+	_, err = waitForOperationWithContext(createCtx, legacy, int64(operation.Id))
 	if err != nil {
 		// Do not return here so that the read method can hydrate the state
 		diags = append(diags, diag.Diagnostic{
@@ -554,17 +562,17 @@ func resourceEndpointRead(ctx context.Context, d *schema.ResourceData, meta inte
 	endpointID := int32(d.Get("endpoint_id").(int))
 
 	endpoint, resp, err := client.VhostsAPI.GetVhost(ctx, endpointID).Execute()
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		log.Printf("Endpoint with ID: %d was deleted outside of Terraform. Removing it from Terraform state.", endpointID)
-		return nil
-	}
 	if err != nil {
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  fmt.Sprintf("Failed to fetch endpoint with ID %d", endpointID),
 			Detail:   err.Error(),
 		})
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		log.Printf("Endpoint with ID: %d was deleted outside of Terraform. Removing it from Terraform state.", endpointID)
+		return nil
 	}
 
 	serviceID := ExtractIdFromLink(endpoint.Links.Service.GetHref())
@@ -808,7 +816,9 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			})
 		}
 
-		_, err = legacy.WaitForOperation(int64(operation.Id))
+		updateCtx, updateCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+		defer updateCancel()
+		_, err = waitForOperationWithContext(updateCtx, legacy, int64(operation.Id))
 		if err != nil {
 			// Do not return here so that the read method can hydrate the state
 			diags = append(diags, diag.Diagnostic{

--- a/aptible/resource_endpoint_test.go
+++ b/aptible/resource_endpoint_test.go
@@ -477,6 +477,22 @@ func TestAccResourceEndpoint_lbAlgorithm(t *testing.T) {
 	})
 }
 
+func TestAccResourceEndpoint_createTimeout(t *testing.T) {
+	appHandle := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAptibleEndpointAppWithCreateTimeout(appHandle, "1s"),
+				ExpectError: regexp.MustCompile(`timed out waiting for operation`),
+			},
+		},
+	})
+}
+
 func TestAccResourceEndpoint_expectError(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -637,6 +653,41 @@ func testAccCheckEndpointDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func testAccAptibleEndpointAppWithCreateTimeout(appHandle string, timeout string) string {
+	return fmt.Sprintf(`
+	resource "aptible_environment" "test" {
+		handle   = "%s"
+		org_id   = "%s"
+		stack_id = "%v"
+	}
+
+	resource "aptible_app" "test" {
+		env_id       = aptible_environment.test.env_id
+		handle       = "%s"
+		docker_image = "quay.io/aptible/nginx-mirror:1"
+		service {
+			process_type           = "cmd"
+			container_memory_limit = 512
+			container_count        = 1
+		}
+	}
+
+	resource "aptible_endpoint" "test" {
+		env_id        = aptible_environment.test.env_id
+		resource_id   = aptible_app.test.app_id
+		resource_type = "app"
+		process_type  = "cmd"
+		endpoint_type = "https"
+		default_domain = true
+		internal      = true
+		platform      = "alb"
+		timeouts {
+			create = "%s"
+		}
+	}
+`, appHandle, testOrganizationId, testStackId, appHandle, timeout)
 }
 
 func testAccAptibleEndpointCustomDomain(appHandle string) string {

--- a/aptible/resource_environment.go
+++ b/aptible/resource_environment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/aptible/aptible-api-go/aptibleapi"
 	"github.com/aptible/go-deploy/aptible"
@@ -22,6 +23,11 @@ func resourceEnvironment() *schema.Resource {
 		DeleteContext: resourceEnvironmentDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceEnvironmentImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"env_id": {

--- a/aptible/resource_log_drain.go
+++ b/aptible/resource_log_drain.go
@@ -1,21 +1,28 @@
 package aptible
 
 import (
+	"context"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/aptible/go-deploy/aptible"
 	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceLogDrain() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLogDrainCreate,
-		Read:   resourceLogDrainRead,
-		Delete: resourceLogDrainDelete,
+		CreateContext: resourceLogDrainCreateContext,
+		ReadContext:   resourceLogDrainReadContext,
+		DeleteContext: resourceLogDrainDeleteContext,
 		Importer: &schema.ResourceImporter{
 			State: resourceLogDrainImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -126,7 +133,7 @@ func resourceLogDrain() *schema.Resource {
 	}
 }
 
-func resourceLogDrainCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLogDrainCreateContext(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*providerMetadata).LegacyClient
 	handle := d.Get("handle").(string)
 	accountID := int64(d.Get("env_id").(int))
@@ -164,15 +171,15 @@ func resourceLogDrainCreate(d *schema.ResourceData, meta interface{}) error {
 	logDrain, err := client.CreateLogDrain(handle, accountID, data)
 	if err != nil {
 		log.Println("There was an error when completing the request to create the log drain.\n[ERROR] -", err)
-		return generateErrorFromClientError(err)
+		return diag.FromErr(generateErrorFromClientError(err))
 	}
 	d.SetId(strconv.Itoa(int(logDrain.ID)))
 	_ = d.Set("log_drain_id", logDrain.ID)
 
-	return resourceLogDrainRead(d, meta)
+	return resourceLogDrainReadContext(context.Background(), d, meta)
 }
 
-func resourceLogDrainRead(d *schema.ResourceData, meta interface{}) error {
+func resourceLogDrainReadContext(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*providerMetadata).LegacyClient
 	logDrainID := int64(d.Get("log_drain_id").(int))
 
@@ -181,7 +188,7 @@ func resourceLogDrainRead(d *schema.ResourceData, meta interface{}) error {
 	logDrain, err := client.GetLogDrain(logDrainID)
 	if err != nil {
 		log.Println(err)
-		return generateErrorFromClientError(err)
+		return diag.FromErr(generateErrorFromClientError(err))
 	}
 	if logDrain.Deleted {
 		d.SetId("")
@@ -216,9 +223,8 @@ func resourceLogDrainRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceLogDrainDelete(d *schema.ResourceData, meta interface{}) error {
-	readErr := resourceLogDrainRead(d, meta)
-	if readErr == nil {
+func resourceLogDrainDeleteContext(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if diags := resourceLogDrainReadContext(ctx, d, meta); !diags.HasError() {
 		logDrainID := int64(d.Get("log_drain_id").(int))
 		client := meta.(*providerMetadata).LegacyClient
 		deleted, err := client.DeleteLogDrain(logDrainID)
@@ -228,7 +234,7 @@ func resourceLogDrainDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 		if err != nil {
 			log.Println("There was an error when completing the request to destroy the log drain.\n[ERROR] -", err)
-			return generateErrorFromClientError(err)
+			return diag.FromErr(generateErrorFromClientError(err))
 		}
 	}
 	d.SetId("")
@@ -238,6 +244,6 @@ func resourceLogDrainDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceLogDrainImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	logDrainID, _ := strconv.Atoi(d.Id())
 	_ = d.Set("log_drain_id", logDrainID)
-	err := resourceLogDrainRead(d, meta)
+	err := diagnosticsToError(resourceLogDrainReadContext(context.Background(), d, meta))
 	return []*schema.ResourceData{d}, err
 }

--- a/aptible/resource_metric_drain.go
+++ b/aptible/resource_metric_drain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/aptible/go-deploy/aptible"
 	"github.com/go-openapi/strfmt"
@@ -22,6 +23,10 @@ func resourceMetricDrain() *schema.Resource {
 		CustomizeDiff: resourceMetricDrainValidate,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceMetricDrainImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/aptible/resource_replica.go
+++ b/aptible/resource_replica.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/aptible/aptible-api-go/aptibleapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -13,15 +14,18 @@ import (
 )
 
 func resourceReplica() *schema.Resource {
-	// Linter gets upset because of the mixed context and non-context methods
-	// lintignore:S024
 	return &schema.Resource{
-		CreateContext: resourceReplicaCreate, // POST
-		Read:          resourceReplicaRead,   // GET
-		UpdateContext: resourceReplicaUpdate, // PUT
-		Delete:        resourceReplicaDelete, // DELETE
+		CreateContext: resourceReplicaCreate,        // POST
+		ReadContext:   resourceReplicaReadContext,   // GET
+		UpdateContext: resourceReplicaUpdate,        // PUT
+		DeleteContext: resourceReplicaDeleteContext, // DELETE
 		Importer: &schema.ResourceImporter{
 			State: resourceReplicaImport,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -127,7 +131,9 @@ func resourceReplicaCreate(ctx context.Context, d *schema.ResourceData, meta int
 		})
 	}
 
-	deleted, err := legacy.WaitForOperation(int64(op.Id))
+	createCtx, createCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+	defer createCancel()
+	deleted, err := waitForOperationWithContext(createCtx, legacy, int64(op.Id))
 	if err != nil {
 		return append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -158,17 +164,17 @@ func resourceReplicaCreate(ctx context.Context, d *schema.ResourceData, meta int
 			Severity: diag.Error,
 			Summary:  "Replica provision operation not found",
 		})
-		return append(diags, diag.FromErr(resourceReplicaRead(d, meta))...)
+		return append(diags, resourceReplicaReadContext(ctx, d, meta)...)
 	}
 	operationID := (*operation).ID
-	deleted, err = legacy.WaitForOperation(operationID)
+	deleted, err = waitForOperationWithContext(createCtx, legacy, operationID)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Failed to provision replica",
 			Detail:   err.Error(),
 		})
-		return append(diags, diag.FromErr(resourceReplicaRead(d, meta))...)
+		return append(diags, resourceReplicaReadContext(ctx, d, meta)...)
 	}
 	if deleted {
 		diags = append(diags, diag.Diagnostic{
@@ -176,7 +182,7 @@ func resourceReplicaCreate(ctx context.Context, d *schema.ResourceData, meta int
 			Summary:  "Failed to provision replica",
 			Detail:   fmt.Sprintf("the replica with handle: %s was unexpectedly deleted", handle),
 		})
-		return append(diags, diag.FromErr(resourceReplicaRead(d, meta))...)
+		return append(diags, resourceReplicaReadContext(ctx, d, meta)...)
 	}
 
 	// Enable backups defaults to `true` in the backend so we only need to do
@@ -206,50 +212,49 @@ func resourceReplicaCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	return append(diags, diag.FromErr(resourceReplicaRead(d, meta))...)
+	return append(diags, resourceReplicaReadContext(ctx, d, meta)...)
 }
 
 func resourceReplicaImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	replicaID, _ := strconv.Atoi(d.Id())
 	_ = d.Set("replica_id", replicaID)
-	err := resourceReplicaRead(d, meta)
+	err := diagnosticsToError(resourceReplicaReadContext(context.Background(), d, meta))
 	return []*schema.ResourceData{d}, err
 }
 
 // syncs Terraform state with changes made via the API outside of Terraform
-func resourceReplicaRead(d *schema.ResourceData, meta interface{}) error {
+func resourceReplicaReadContext(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	databaseID := int32(d.Get("replica_id").(int))
 
 	client := meta.(*providerMetadata).Client
-	ctx := context.Background()
 	ctx = meta.(*providerMetadata).APIContext(ctx)
 
 	database, resp, err := client.DatabasesAPI.GetDatabase(ctx, databaseID).Execute()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		log.Println("Database with ID: " + strconv.Itoa(int(databaseID)) + " was deleted outside of Terraform. Now removing it from Terraform state.")
 		return nil
 	}
-	if err != nil {
-		return err
-	}
 
 	imageID := ExtractIdFromLink(database.Links.DatabaseImage.GetHref())
 	if imageID == 0 {
-		return fmt.Errorf("Could not find database image ID")
+		return diag.FromErr(fmt.Errorf("Could not find database image ID"))
 	}
 	serviceID := ExtractIdFromLink(database.Links.Service.GetHref())
 	if serviceID == 0 {
-		return fmt.Errorf("Could not find database service ID")
+		return diag.FromErr(fmt.Errorf("Could not find database service ID"))
 	}
 	accountID := ExtractIdFromLink(database.Links.Account.GetHref())
 	if accountID == 0 {
-		return fmt.Errorf("Could not find database account ID")
+		return diag.FromErr(fmt.Errorf("Could not find database account ID"))
 	}
 
 	service, _, err := client.ServicesAPI.GetServiceWithOperationStatus(ctx, serviceID).Execute()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	containerSize := service.GetContainerMemoryLimitMb()
@@ -355,7 +360,9 @@ func resourceReplicaUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			return diags
 		}
 
-		del, err := legacy.WaitForOperation(int64(op.Id))
+		updateCtx, updateCancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+		defer updateCancel()
+		del, err := waitForOperationWithContext(updateCtx, legacy, int64(op.Id))
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -382,24 +389,16 @@ func resourceReplicaUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		log.Printf("[WARN] In order for the new database name (%s) to appear in log drain and metric drain destinations, you must restart the database.\n", handle)
 	}
 
-	if err := resourceReplicaRead(d, meta); err != nil {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "There was an error when trying to retrieve the updated state of the database.",
-			Detail:   err.Error(),
-		})
-	}
-
-	return diags
+	return append(diags, resourceReplicaReadContext(ctx, d, meta)...)
 }
 
-func resourceReplicaDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceReplicaDeleteContext(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*providerMetadata).LegacyClient
 	replicaID := int64(d.Get("replica_id").(int))
 	err := client.DeleteReplica(replicaID)
 	if err != nil {
 		log.Println(err)
-		return generateErrorFromClientError(err)
+		return diag.FromErr(generateErrorFromClientError(err))
 	}
 
 	d.SetId("")

--- a/aptible/wait.go
+++ b/aptible/wait.go
@@ -1,0 +1,30 @@
+package aptible
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aptible/go-deploy/aptible"
+)
+
+func waitForOperationWithContext(ctx context.Context, legacy *aptible.Client, operationID int64) (bool, error) {
+	return waitForOperationWithPoll(ctx, legacy.WaitForOperation, operationID)
+}
+
+func waitForOperationWithPoll(ctx context.Context, poll func(int64) (bool, error), operationID int64) (bool, error) {
+	type result struct {
+		deleted bool
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		deleted, err := poll(operationID)
+		ch <- result{deleted, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return false, fmt.Errorf("timed out waiting for operation %d: %w", operationID, ctx.Err())
+	case r := <-ch:
+		return r.deleted, r.err
+	}
+}

--- a/aptible/wait_test.go
+++ b/aptible/wait_test.go
@@ -45,7 +45,7 @@ func TestWaitForOperationWithPoll_deleted(t *testing.T) {
 func TestWaitForOperationWithPoll_timeout(t *testing.T) {
 	// poll blocks until the context is cancelled
 	poll := func(_ int64) (bool, error) {
-		time.Sleep(10 * time.Second)
+		time.Sleep(10 * time.Second) //lintignore:R018
 		return false, nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)

--- a/aptible/wait_test.go
+++ b/aptible/wait_test.go
@@ -1,0 +1,64 @@
+package aptible
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitForOperationWithPoll_success(t *testing.T) {
+	poll := func(_ int64) (bool, error) { return false, nil }
+	ctx := context.Background()
+	deleted, err := waitForOperationWithPoll(ctx, poll, 42)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if deleted {
+		t.Fatal("expected deleted=false")
+	}
+}
+
+func TestWaitForOperationWithPoll_pollError(t *testing.T) {
+	pollErr := errors.New("operation failed")
+	poll := func(_ int64) (bool, error) { return false, pollErr }
+	ctx := context.Background()
+	_, err := waitForOperationWithPoll(ctx, poll, 42)
+	if !errors.Is(err, pollErr) {
+		t.Fatalf("expected poll error, got %v", err)
+	}
+}
+
+func TestWaitForOperationWithPoll_deleted(t *testing.T) {
+	poll := func(_ int64) (bool, error) { return true, nil }
+	ctx := context.Background()
+	deleted, err := waitForOperationWithPoll(ctx, poll, 42)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deleted=true")
+	}
+}
+
+func TestWaitForOperationWithPoll_timeout(t *testing.T) {
+	// poll blocks until the context is cancelled
+	poll := func(_ int64) (bool, error) {
+		time.Sleep(10 * time.Second)
+		return false, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := waitForOperationWithPoll(ctx, poll, 99)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for operation 99") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected error to wrap context.DeadlineExceeded, got %v", err)
+	}
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -232,3 +232,21 @@ resource "aptible_replica" "REPLICA_HANDLE" {
 ## Argument Reference
 
 There are currently no arguments to provide directly to the provider
+
+
+## Timeouts
+
+Operations on most resources will time out after 20 minutes by default. You can override these values with a `timeouts` block:
+
+```hcl
+resource "aptible_app" "example_app" {
+  env_id = 123
+  handle = "example_app"
+
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "10m"
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -236,7 +236,7 @@ There are currently no arguments to provide directly to the provider
 
 ## Timeouts
 
-Operations on most resources will time out after 20 minutes by default. You can override these values with a `timeouts` block:
+Operations on most resources will time out after 90 minutes by default. You can override these values with a `timeouts` block:
 
 ```hcl
 resource "aptible_app" "example_app" {


### PR DESCRIPTION
Adds timeouts so if users are running into longer than average deployment/provision times, they can tune the timeouts and ensure they allow for the extra time.

As an example of running into timeouts:
<img width="678" height="317" alt="Screenshot 2026-06-16 at 4 18 42 PM" src="https://github.com/user-attachments/assets/df353e36-356c-45f7-b7fb-b4ca25ff7149" />
